### PR TITLE
Senha mínima fraca para contas admin

### DIFF
--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator'
+import { IsEmail, IsString, Matches, MinLength } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 
 export class LoginDto {
@@ -8,6 +8,9 @@ export class LoginDto {
 
   @ApiProperty()
   @IsString()
-  @MinLength(6)
+  @MinLength(12, { message: 'Password must be at least 12 characters' })
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/, {
+    message: 'Password must contain uppercase, lowercase, number and special character',
+  })
   password: string
 }


### PR DESCRIPTION
Atualiza `LoginDto` para exigir senha de no mínimo 12 caracteres com pelo menos uma letra maiúscula, minúscula, número e caractere especial, elevando o padrão de segurança para contas administrativas.

Closes #12