### PR TITLE
Filtro global de exceções

### DIFF
--- a/backend/src/common/filters/global-exception.filter.ts
+++ b/backend/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,24 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from '@nestjs/common'
+import { Response } from 'express'
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+
+    let status = 500
+    let message = 'Internal server error'
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus()
+      message = exception.message
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      message,
+      timestamp: new Date().toISOString(),
+    })
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import * as cookieParser from 'cookie-parser'
 import helmet from 'helmet'
 import { AppModule } from './app.module'
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
@@ -20,6 +21,8 @@ async function bootstrap() {
   app.use(helmet())
   app.use(cookieParser())
   app.enableCors({ origin: corsOrigin, credentials: true })
+
+  app.useGlobalFilters(new GlobalExceptionFilter())
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
Cria `GlobalExceptionFilter` em `common/filters/` e registra em `main.ts`. Exceções não tratadas agora retornam um JSON sanitizado com `statusCode`, `message` e `timestamp`, sem vazar stack traces ou detalhes internos para o cliente.

Closes #6