### PR TITLE
Chave de API estática para Clinic API sem política de rotação

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,4 +4,9 @@ PORT=3001
 CORS_ORIGIN="https://your-admin-frontend-url.com"
 NODE_ENV="production"
 CLINIC_API_URL="https://api.careflow.com.br"
-CLINIC_INTERNAL_API_KEY="your-strong-shared-secret"
+# CLINIC_INTERNAL_API_KEY — shared secret used in x-internal-api-key header for machine-to-machine calls.
+# Rotation policy: rotate every 90 days or immediately upon suspected compromise.
+# Steps: generate a new high-entropy secret (min 32 chars), update both services simultaneously,
+# verify connectivity, then revoke the old key.
+# Future: replace with short-lived JWT (machine-to-machine) to eliminate the need for manual rotation.
+CLINIC_INTERNAL_API_KEY="your-strong-shared-secret-min-32-chars"

--- a/backend/src/clinic-api/clinic-api.service.ts
+++ b/backend/src/clinic-api/clinic-api.service.ts
@@ -33,6 +33,9 @@ export class ClinicApiService {
     return this.config.getOrThrow<string>('CLINIC_API_URL')
   }
 
+  // CLINIC_INTERNAL_API_KEY is a static shared secret. Rotate every 90 days or
+  // immediately if compromised. See .env.example for the rotation procedure.
+  // Future improvement: replace with short-lived machine-to-machine JWT tokens.
   private get headers(): Record<string, string> {
     return {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Documenta a política de rotação da `CLINIC_INTERNAL_API_KEY` em `.env.example` (ciclo de 90 dias, passos de revogação de emergência, caminho de migração futura para JWT machine-to-machine) e adiciona comentário co-localizado em `ClinicApiService` para manter a política visível no ponto de uso.

Closes #16