### PR TITLE
fix: move password complexity rules from LoginDto to CreateAdminDto

### DIFF
--- a/backend/src/auth/dto/create-admin.dto.ts
+++ b/backend/src/auth/dto/create-admin.dto.ts
@@ -1,0 +1,25 @@
+import { IsEmail, IsEnum, IsString, Matches, MinLength } from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+import { AdminRole } from '@prisma/client'
+
+export class CreateAdminDto {
+  @ApiProperty({ example: 'João Silva' })
+  @IsString()
+  name: string
+
+  @ApiProperty({ example: 'joao@careflow.com.br' })
+  @IsEmail()
+  email: string
+
+  @ApiProperty()
+  @IsString()
+  @MinLength(12, { message: 'Password must be at least 12 characters' })
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/, {
+    message: 'Password must contain uppercase, lowercase, number and special character',
+  })
+  password: string
+
+  @ApiProperty({ enum: AdminRole })
+  @IsEnum(AdminRole)
+  role: AdminRole
+}

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, Matches, MinLength } from 'class-validator'
+import { IsEmail, IsString } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 
 export class LoginDto {
@@ -8,9 +8,5 @@ export class LoginDto {
 
   @ApiProperty()
   @IsString()
-  @MinLength(12, { message: 'Password must be at least 12 characters' })
-  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/, {
-    message: 'Password must contain uppercase, lowercase, number and special character',
-  })
   password: string
 }


### PR DESCRIPTION
## Problema

A implementação anterior adicionou `@MinLength(12)` e `@Matches(...)` no `LoginDto`. Isso causa um lockout silencioso: qualquer admin com senha que não satisfaça as regras (ex.: criada antes da política, ou o próprio seed com `changeme123`) recebe um **400 de validação antes do bcrypt ser consultado**, tornando o login impossível.

## Correção

- **`LoginDto`**: removidas as regras de complexidade — mantém apenas `@IsString()`. A autenticação em si já rejeita senhas erradas com 401.
- **`CreateAdminDto`** (novo): recebe as regras `@MinLength(12)` + `@Matches(...)` para uso no endpoint de criação de admin quando implementado.

A validação de força de senha pertence à criação/reset, não ao login.

Closes #12