### PR TITLE
chore: add version metadata to docker images and /version endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,11 @@ All development MUST follow this process — no exceptions:
 
 ## Overview
 
-CareFlow Admin is a full-stack SaaS admin dashboard for managing clinic organizations, subscription plans, billing, and metrics. It consists of a React frontend and a NestJS backend in separate subdirectories.
+CareFlow Admin is a full-stack SaaS admin dashboard for managing clinic organizations, subscription plans, billing, and metrics — the **operator back-office** of the `careflow-ui` clinic product. It consists of a React frontend (`frontend/`) and a NestJS backend (`backend/`) in separate subdirectories.
+
+**Package manager**: **Bun** (`bun.lock` is the lockfile of record in both `backend/` and `frontend/`). Do not commit `package-lock.json`.
+
+See the parent `C:/Repos/Careflow/CLAUDE.md` for how this project talks to `careflow-ui` (shared `INTERNAL_API_KEY`, no cross-DB FKs — integration is HTTP-only via the `clinic-api/` module).
 
 ---
 
@@ -63,26 +67,26 @@ CareFlow Admin is a full-stack SaaS admin dashboard for managing clinic organiza
 ### Frontend (`frontend/`)
 
 ```bash
-npm run dev        # Start Vite dev server on port 8081
-npm run build      # TypeScript check + production build
-npm run lint       # ESLint on src/
-npm run preview    # Preview production build
+bun run dev        # Start Vite dev server on port 8081
+bun run build      # tsc -b + vite build
+bun run lint       # ESLint on src/
+bun run preview    # Preview production build
 ```
 
 ### Backend (`backend/`)
 
 ```bash
-npm run start:dev          # NestJS watch mode (loads .env.dev via dotenvx)
-npm run build              # Compile to dist/
-npm run lint               # ESLint on src/ and test/
-npm run test               # Jest tests
+bun run start:dev          # NestJS watch mode (loads .env.dev via dotenvx)
+bun run build              # nest build → dist/
+bun run lint               # ESLint on src/ and test/
+bun run test               # Jest tests
 
 # Prisma
-npm run prisma:generate        # Regenerate Prisma client after schema changes
-npm run prisma:migrate:dev     # Run dev migrations
-npm run prisma:migrate:deploy  # Deploy migrations to production
-npm run prisma:seed            # Seed database (ts-node)
-npm run prisma:studio          # Open Prisma Studio UI
+bun run prisma:generate        # Regenerate Prisma client after schema changes
+bun run prisma:migrate:dev     # Run dev migrations
+bun run prisma:migrate:deploy  # Deploy migrations to production
+bun run prisma:seed            # Seed database (ts-node)
+bun run prisma:studio          # Open Prisma Studio UI
 ```
 
 ### Environment Setup
@@ -91,9 +95,13 @@ Copy `backend/.env.example` to `backend/.env.dev` and populate:
 - `DATABASE_ADMIN_URL` — PostgreSQL connection string
 - `JWT_ADMIN_SECRET` — JWT signing secret
 - `PORT` — Backend port (default 3001)
-- `CORS_ORIGIN` — Frontend URL for CORS
-- `CLINIC_API_URL` — External CareFlow clinic API base URL
-- `CLINIC_INTERNAL_API_KEY` — Shared secret for clinic API requests
+- `CORS_ORIGIN` — Frontend URL for CORS (required in production)
+- `CLINIC_API_URL` — Base URL of the careflow-ui clinic API (e.g. `http://localhost:3000`). The admin appends `/api/internal/*` — do **not** include the path prefix in this value.
+- `CLINIC_INTERNAL_API_KEY` — Shared secret for clinic API requests. Must match `INTERNAL_API_KEY` on the clinic side.
+
+### Docker
+
+Both frontend and backend have a `Dockerfile`. The backend uses `docker-entrypoint.sh`, which runs `prisma migrate deploy` + seed on startup (idempotent; set `RUN_SEED=false` to skip seeding). Both containers install via Bun. End-to-end orchestration with the clinic product lives in the parent `docker-compose.yml`.
 
 ---
 
@@ -104,19 +112,28 @@ Copy `backend/.env.example` to `backend/.env.dev` and populate:
 React SPA (React Router DOM 7) with:
 - **Server state**: TanStack React Query — all API calls use query hooks with caching/refetch
 - **Auth state**: `contexts/AdminAuthContext.tsx` — stores user in React state, session validated via `GET /auth/me` on mount; provides `useAdminAuth()`
-- **HTTP client**: `lib/api.ts` — Axios instance with `withCredentials: true` (sends httpOnly cookie automatically) and redirects to `/login` on 401
-- **Forms**: React Hook Form + Zod validation
+- **HTTP client**: `lib/api.ts` — Axios instance with `withCredentials: true` (sends httpOnly `admin_token` cookie automatically) and redirects to `/login` on 401. No token stored in JS.
+- **Toast**: `contexts/ToastContext.tsx` — `useToast()` with `toast.success/error`; use `getErrorMessage(err)` from `lib/utils.ts` to extract server messages
+- **Forms**: React Hook Form + Zod validation (including `superRefine` for conditional validation in multi-mode forms)
 - **Styling**: Tailwind CSS with CSS variable-based theming; `ui/` primitives are Radix UI wrappers
 
-**Routing**: Protected by `components/auth/ProtectedRoute.tsx`. Layout routes under `/` render `AdminLayout` → `AdminSidebar` + `AdminTopBar` with nested pages.
+**Routing**: Protected by `components/auth/ProtectedRoute.tsx`. Layout routes under `/` render `AdminLayout` → `AdminSidebar` + `AdminTopBar` with nested pages (Dashboard, Organizations, OrganizationDetail, Plans, Subscriptions, Invoices).
 
 **Path alias**: `@/*` resolves to `src/*`
 
 **Dev proxy**: Vite proxies `/api/*` → `http://localhost:3001` — no hardcoded backend URL in frontend code.
 
+**Formatters** (`lib/utils.ts`): `formatCurrency`, `formatDate`, `formatCNPJ`, `formatCPF`, `getErrorMessage`, `cn` (tailwind-merge).
+
 ### Backend (`backend/src/`)
 
-NestJS API on port 3001. Global prefix `/api/admin`. Swagger docs at `/api/admin/docs`.
+NestJS 11 API on port 3001. Global prefix `/api/admin`. Swagger docs at `/api/admin/docs`.
+
+**Top-level middleware** (in `main.ts`):
+- `helmet()` — security headers
+- `cookie-parser` — required to read the `admin_token` httpOnly cookie
+- `ValidationPipe` global (whitelist + transform)
+- CORS with `credentials: true` (to accept the cookie); `CORS_ORIGIN` must be set to a production domain in prod or startup fails
 
 **Module layout** — each feature follows a layered pattern:
 - `dto/` — request/response shapes (class-validator decorators)
@@ -124,24 +141,41 @@ NestJS API on port 3001. Global prefix `/api/admin`. Swagger docs at `/api/admin
 - `application/` — use cases (single-responsibility classes)
 - `infra/` — Prisma repository implementations and external service clients
 
-**Auth**: JWT via Passport (`auth/strategies/`). Guards:
-- `JwtAuthGuard` — verifies token, applied globally or per-controller
+**Rate limiting**: `@nestjs/throttler` applied globally in `AppModule` with a default of 100 req/min. Endpoints that do auth-heavy work (password reset, login) are candidates for a stricter per-route `@Throttle()` — see the open tracking issues (e.g. reset-password rate limit).
+
+**Auth**: JWT via Passport (`auth/strategies/jwt.strategy.ts`) reading the token from the httpOnly cookie `admin_token`. Guards:
+- `JwtAuthGuard` — verifies token (applied per-controller via `@UseGuards`)
 - `RolesGuard` — checks `@Roles()` decorator against `AdminRole` enum
 
-**Admin roles**: `SUPER_ADMIN`, `FINANCE`, `SUPPORT` — defined in Prisma schema and `types/admin.ts`
+Login issues the cookie server-side; logout clears it.
 
-**External integration**: `clinic-api/` module calls the CareFlow clinic service using a shared internal API key (`CLINIC_INTERNAL_API_KEY` header). This is used to resolve clinic data without cross-database foreign keys.
+**Admin roles**: `SUPER_ADMIN`, `FINANCE`, `SUPPORT` — defined in Prisma schema and `types/admin.ts`.
+
+**External integration (`clinic-api/`)**: the `ClinicApiService` is the single seam that talks to the careflow-ui clinic backend over HTTP using the shared `CLINIC_INTERNAL_API_KEY` header. It:
+- Appends `/api/internal/*` to `CLINIC_API_URL` — the clinic product sets a `/api` global prefix, so do **not** call `/internal/*` directly.
+- Builds outbound URLs via a `buildUrl` tagged-template helper that `encodeURIComponent`-s every dynamic segment and asserts the final `URL.origin` matches the configured base — this blocks SSRF / path-traversal when ids come from HTTP params.
+- Supported operations: clinic create/list, access update, **person upsert**, **link person to clinic (ADMIN/PROFESSIONAL/RECEPTIONIST)**, **list/update/reset-password clinic users**.
+
+**Organizations module**: houses the bulk of the cross-system orchestration. Use cases in `organizations/application/`:
+- `create-organization.usecase.ts` — legacy flow that links an existing clinic by `clinicExternalId`
+- `create-organization-with-owner.usecase.ts` — the standard flow (see sequence diagram in parent repo `docs/sequence.mermaid`): creates Clinic → upserts Person responsável by CPF → links as ADMIN → persists Organization locally. Idempotent: reusing CPF returns the existing Person with `provisionalPassword: null`.
+- `provisional-password.ts` — generates provisional passwords with `crypto.randomInt` (rejection sampling — do NOT use `randomBytes % alphabet.length`, that's biased).
+- `reset-clinic-user-password.usecase.ts` — generates a new provisional password and invalidates the previous one via the clinic-api.
+- `resolve-clinic-id.ts` — helper that converts admin `organizationId` → `clinicExternalId` before any clinic-api call (since the two DBs share only that link).
+- `list-organizations.usecase.ts`, `update-status.usecase.ts` — listing + status transitions.
 
 ### Database (Prisma + PostgreSQL)
 
-Schema at `backend/prisma/schema.prisma`. Core models:
+Schema at `backend/prisma/schema.prisma`. Core models (all IDs are UUIDs):
 - `AdminUser` — internal admin accounts with `role`
-- `Organization` — SaaS customers (status: `ACTIVE | SUSPENDED | CANCELED`)
+- `Organization` — SaaS customers. Linked to the clinic product via `clinicExternalId`. Status: `ACTIVE | SUSPENDED | CANCELED`
 - `Plan` — subscription tiers with pricing and feature flags
 - `Subscription` — links Organization → Plan (status: `TRIAL | ACTIVE | PAST_DUE | CANCELED`)
 - `Invoice` — billing records per subscription
 
-After any schema change run `prisma:generate` to update the Prisma client, then `prisma:migrate:dev` to create and apply a migration.
+The admin DB knows nothing about Persons, OrganizationUsers, Patients, or Appointments — those live in the clinic product and are reached only via `clinic-api/`.
+
+After any schema change run `bun run prisma:generate` to update the Prisma client, then `bun run prisma:migrate:dev` to create and apply a migration.
 
 ### Path Aliases
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,6 +31,21 @@ COPY --from=builder /app/prisma ./prisma
 COPY docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 
+# Version identification — read at runtime by GET /api/admin/version.
+# Override via docker build --build-arg APP_VERSION=... GIT_SHA=... BUILT_AT=...
+ARG APP_VERSION=dev
+ARG GIT_SHA=unknown
+ARG BUILT_AT=unknown
+ENV APP_VERSION=$APP_VERSION \
+    GIT_SHA=$GIT_SHA \
+    BUILT_AT=$BUILT_AT
+
+LABEL org.opencontainers.image.title="careflow-admin-api" \
+      org.opencontainers.image.version=$APP_VERSION \
+      org.opencontainers.image.revision=$GIT_SHA \
+      org.opencontainers.image.created=$BUILT_AT \
+      org.opencontainers.image.source="https://github.com/brav-lima/careflow-admin"
+
 EXPOSE 3001
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { SubscriptionsModule } from './subscriptions/subscriptions.module'
 import { InvoicesModule } from './invoices/invoices.module'
 import { MetricsModule } from './metrics/metrics.module'
 import { ClinicApiModule } from './clinic-api/clinic-api.module'
+import { VersionModule } from './version/version.module'
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { ClinicApiModule } from './clinic-api/clinic-api.module'
     SubscriptionsModule,
     InvoicesModule,
     MetricsModule,
+    VersionModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/version/version.controller.ts
+++ b/backend/src/version/version.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common'
+import { ApiTags } from '@nestjs/swagger'
+
+@ApiTags('version')
+@Controller('version')
+export class VersionController {
+  @Get()
+  get() {
+    return {
+      version: process.env.APP_VERSION ?? 'dev',
+      gitSha: process.env.GIT_SHA ?? 'unknown',
+      builtAt: process.env.BUILT_AT ?? 'unknown',
+    }
+  }
+}

--- a/backend/src/version/version.module.ts
+++ b/backend/src/version/version.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common'
+import { VersionController } from './version.controller'
+
+@Module({
+  controllers: [VersionController],
+})
+export class VersionModule {}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,9 +7,27 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 COPY . .
+
+# Version identification — baked into the bundle at build time.
+ARG APP_VERSION=dev
+ARG GIT_SHA=unknown
+ARG BUILT_AT=unknown
+ENV VITE_APP_VERSION=$APP_VERSION \
+    VITE_GIT_SHA=$GIT_SHA \
+    VITE_BUILT_AT=$BUILT_AT
+
 RUN bun run build
 
 FROM nginx:alpine AS runner
+
+ARG APP_VERSION=dev
+ARG GIT_SHA=unknown
+ARG BUILT_AT=unknown
+LABEL org.opencontainers.image.title="careflow-admin-web" \
+      org.opencontainers.image.version=$APP_VERSION \
+      org.opencontainers.image.revision=$GIT_SHA \
+      org.opencontainers.image.created=$BUILT_AT \
+      org.opencontainers.image.source="https://github.com/brav-lima/careflow-admin"
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/src/components/layout/AdminSidebar.tsx
+++ b/frontend/src/components/layout/AdminSidebar.tsx
@@ -1,6 +1,7 @@
 import { NavLink } from 'react-router-dom'
 import { LayoutDashboard, Building2, CreditCard, FileText, Settings } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { appVersion, versionTooltip } from '@/lib/version'
 
 const navItems = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
@@ -39,7 +40,9 @@ export function AdminSidebar() {
       </nav>
 
       <div className="px-3 py-4 border-t border-sidebar-border">
-        <p className="text-xs text-sidebar-foreground/40 px-3">v0.1.0</p>
+        <p className="text-xs text-sidebar-foreground/40 px-3" title={versionTooltip}>
+          {appVersion}
+        </p>
       </div>
     </aside>
   )

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -1,0 +1,5 @@
+export const appVersion = import.meta.env.VITE_APP_VERSION ?? 'dev'
+export const gitSha = import.meta.env.VITE_GIT_SHA ?? 'unknown'
+export const builtAt = import.meta.env.VITE_BUILT_AT ?? 'unknown'
+
+export const versionTooltip = `version: ${appVersion}\nrevision: ${gitSha}\nbuilt: ${builtAt}`

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_VERSION?: string
+  readonly VITE_GIT_SHA?: string
+  readonly VITE_BUILT_AT?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- Bake `APP_VERSION`, `GIT_SHA`, `BUILT_AT` as build args into both Dockerfiles and expose them via OCI image labels.
- Backend: new `VersionModule` serving `GET /api/admin/version` with `{ version, gitSha, builtAt }`.
- Frontend: reads `VITE_APP_VERSION` / `VITE_GIT_SHA` / `VITE_BUILT_AT` at build time; `AdminSidebar` footer now displays the real version with a tooltip (`version / revision / built`) instead of the hardcoded `v0.1.0`.
- Also refreshes `CLAUDE.md` to match current repo state (Bun-based commands, Helmet/Throttler/cookie-parser globals, clinic-api SSRF hardening).

## Test plan
- [ ] Build images with `--build-arg APP_VERSION=... --build-arg GIT_SHA=... --build-arg BUILT_AT=...` and confirm `docker inspect` shows populated `org.opencontainers.image.*` labels on both services.
- [ ] Hit `GET /api/admin/version` — returns populated fields.
- [ ] Frontend sidebar footer shows the version; tooltip shows revision/built.
- [ ] When args are omitted, backend returns `dev`/`unknown`/`unknown`; frontend shows `dev`.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)