### PR TITLE
feat(auth): refresh token rotation com cookie httpOnly

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 DATABASE_ADMIN_URL="postgresql://user:password@host:5432/careflow_admin"
 JWT_ADMIN_SECRET="your-strong-secret-here"
+JWT_ADMIN_REFRESH_SECRET="another-strong-secret-distinct-from-the-access-secret"
 PORT=3001
 CORS_ORIGIN="https://your-admin-frontend-url.com"
 NODE_ENV="production"

--- a/backend/prisma/migrations/20260425173311_add_admin_refresh_tokens/migration.sql
+++ b/backend/prisma/migrations/20260425173311_add_admin_refresh_tokens/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "admin_refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "revoked_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "admin_refresh_tokens_token_hash_key" ON "admin_refresh_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "admin_refresh_tokens_user_id_idx" ON "admin_refresh_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "admin_refresh_tokens_expires_at_idx" ON "admin_refresh_tokens"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "admin_refresh_tokens" ADD CONSTRAINT "admin_refresh_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "admin_users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,7 +27,29 @@ model AdminUser {
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime  @updatedAt @map("updated_at")
 
+  refreshTokens AdminRefreshToken[]
+
   @@map("admin_users")
+}
+
+// ──────────────────────────────────────────────
+// AdminRefreshToken — refresh tokens com rotação
+// Apenas o hash é armazenado; o token em claro vive somente no cookie httpOnly
+// ──────────────────────────────────────────────
+
+model AdminRefreshToken {
+  id        String    @id @default(uuid())
+  userId    String    @map("user_id")
+  tokenHash String    @unique @map("token_hash")
+  expiresAt DateTime  @map("expires_at")
+  revokedAt DateTime? @map("revoked_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  user AdminUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("admin_refresh_tokens")
 }
 
 // ──────────────────────────────────────────────

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,12 +1,36 @@
-import { Controller, Post, Get, Body, UseGuards, Res } from '@nestjs/common'
+import { Controller, Post, Get, Body, UseGuards, Res, Req } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler'
-import { Response } from 'express'
+import { Request, Response, CookieOptions } from 'express'
 import { AuthService } from './auth.service'
 import { LoginDto } from './dto/login.dto'
 import { JwtAuthGuard } from './guards/jwt-auth.guard'
+import { JwtRefreshGuard } from './guards/jwt-refresh.guard'
 import { CurrentUser } from './decorators/current-user.decorator'
+import { CurrentRefreshUser, RefreshUser } from './decorators/current-refresh-user.decorator'
 import { Public } from './decorators/public.decorator'
+import { REFRESH_COOKIE_NAME } from './strategies/jwt-refresh.strategy'
+
+const ACCESS_COOKIE_NAME = 'admin_token'
+const ACCESS_TOKEN_MAX_AGE_MS = 8 * 60 * 60 * 1000
+const REFRESH_COOKIE_PATH = '/api/admin/auth'
+
+const isProd = () => process.env.NODE_ENV === 'production'
+
+const accessCookieOptions = (): CookieOptions => ({
+  httpOnly: true,
+  secure: isProd(),
+  sameSite: 'strict',
+  maxAge: ACCESS_TOKEN_MAX_AGE_MS,
+})
+
+const refreshCookieOptions = (maxAgeMs: number): CookieOptions => ({
+  httpOnly: true,
+  secure: isProd(),
+  sameSite: 'strict',
+  maxAge: maxAgeMs,
+  path: REFRESH_COOKIE_PATH,
+})
 
 @ApiTags('auth')
 @Controller('auth')
@@ -18,20 +42,49 @@ export class AuthController {
   @Throttle({ default: { limit: 5, ttl: 60000 } })
   @Post('login')
   async login(@Body() dto: LoginDto, @Res({ passthrough: true }) res: Response) {
-    const { accessToken, user } = await this.authService.login(dto)
-    res.cookie('admin_token', accessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
-      maxAge: 8 * 60 * 60 * 1000,
-    })
+    const { accessToken, refreshToken, refreshTokenMaxAgeMs, user } =
+      await this.authService.login(dto)
+    res.cookie(ACCESS_COOKIE_NAME, accessToken, accessCookieOptions())
+    res.cookie(REFRESH_COOKIE_NAME, refreshToken, refreshCookieOptions(refreshTokenMaxAgeMs))
     return { user }
   }
 
   @Public()
+  @UseGuards(JwtRefreshGuard)
+  @Post('refresh')
+  async refresh(
+    @CurrentRefreshUser() refreshUser: RefreshUser,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const { accessToken, refreshToken, refreshTokenMaxAgeMs } =
+      await this.authService.rotateRefreshToken(refreshUser.userId, refreshUser.jti)
+    res.cookie(ACCESS_COOKIE_NAME, accessToken, accessCookieOptions())
+    res.cookie(REFRESH_COOKIE_NAME, refreshToken, refreshCookieOptions(refreshTokenMaxAgeMs))
+    return { ok: true }
+  }
+
+  @Public()
   @Post('logout')
-  logout(@Res({ passthrough: true }) res: Response) {
-    res.clearCookie('admin_token', { httpOnly: true, sameSite: 'strict' })
+  async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME] as string | undefined
+    if (refreshToken) {
+      try {
+        const decoded = JSON.parse(
+          Buffer.from(refreshToken.split('.')[1] ?? '', 'base64url').toString('utf8'),
+        ) as { jti?: string }
+        if (decoded?.jti) {
+          await this.authService.revokeRefreshToken(decoded.jti)
+        }
+      } catch {
+        // malformed token in cookie — clear it anyway
+      }
+    }
+    res.clearCookie(ACCESS_COOKIE_NAME, { httpOnly: true, sameSite: 'strict' })
+    res.clearCookie(REFRESH_COOKIE_NAME, {
+      httpOnly: true,
+      sameSite: 'strict',
+      path: REFRESH_COOKIE_PATH,
+    })
     return { ok: true }
   }
 

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config'
 import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
 import { JwtStrategy } from './strategies/jwt.strategy'
+import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy'
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { JwtStrategy } from './strategies/jwt.strategy'
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, JwtRefreshStrategy],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,14 +1,27 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import { JwtService } from '@nestjs/jwt'
 import * as bcrypt from 'bcrypt'
+import * as crypto from 'crypto'
 import { PrismaService } from '../prisma/prisma.service'
 import { LoginDto } from './dto/login.dto'
+import { JwtRefreshPayload } from './strategies/jwt-refresh.strategy'
+
+const REFRESH_TTL_DAYS = 7
+const REFRESH_TTL_MS = REFRESH_TTL_DAYS * 24 * 60 * 60 * 1000
+
+export interface IssuedTokens {
+  accessToken: string
+  refreshToken: string
+  refreshTokenMaxAgeMs: number
+}
 
 @Injectable()
 export class AuthService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwt: JwtService,
+    private readonly config: ConfigService,
   ) {}
 
   async login(dto: LoginDto) {
@@ -25,11 +38,10 @@ export class AuthService {
       throw new UnauthorizedException('Credenciais inválidas')
     }
 
-    const payload = { sub: user.id, role: user.role }
-    const token = this.jwt.sign(payload)
+    const tokens = await this.issueTokens(user.id, user.role)
 
     return {
-      accessToken: token,
+      ...tokens,
       user: {
         id: user.id,
         name: user.name,
@@ -48,5 +60,78 @@ export class AuthService {
     if (!user) throw new UnauthorizedException()
 
     return user
+  }
+
+  async rotateRefreshToken(userId: string, jti: string): Promise<IssuedTokens> {
+    const tokenHash = this.hashJti(jti)
+    const stored = await this.prisma.adminRefreshToken.findUnique({
+      where: { tokenHash },
+    })
+
+    if (!stored || stored.userId !== userId) {
+      throw new UnauthorizedException('Refresh token inválido')
+    }
+
+    if (stored.revokedAt) {
+      // Reuse detection: presented token was already rotated. Revoke the whole family.
+      await this.prisma.adminRefreshToken.updateMany({
+        where: { userId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      })
+      throw new UnauthorizedException('Refresh token reutilizado')
+    }
+
+    if (stored.expiresAt.getTime() <= Date.now()) {
+      throw new UnauthorizedException('Refresh token expirado')
+    }
+
+    const user = await this.prisma.adminUser.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true, active: true },
+    })
+    if (!user || !user.active) {
+      throw new UnauthorizedException('Usuário inativo')
+    }
+
+    await this.prisma.adminRefreshToken.update({
+      where: { id: stored.id },
+      data: { revokedAt: new Date() },
+    })
+
+    return this.issueTokens(user.id, user.role)
+  }
+
+  async revokeRefreshToken(jti: string): Promise<void> {
+    const tokenHash = this.hashJti(jti)
+    await this.prisma.adminRefreshToken.updateMany({
+      where: { tokenHash, revokedAt: null },
+      data: { revokedAt: new Date() },
+    })
+  }
+
+  private async issueTokens(userId: string, role: string): Promise<IssuedTokens> {
+    const accessToken = this.jwt.sign({ sub: userId, role })
+
+    const jti = crypto.randomUUID()
+    const expiresAt = new Date(Date.now() + REFRESH_TTL_MS)
+    const refreshPayload: JwtRefreshPayload = { sub: userId, jti }
+    const refreshToken = this.jwt.sign(refreshPayload, {
+      secret: this.config.getOrThrow<string>('JWT_ADMIN_REFRESH_SECRET'),
+      expiresIn: `${REFRESH_TTL_DAYS}d`,
+    })
+
+    await this.prisma.adminRefreshToken.create({
+      data: {
+        userId,
+        tokenHash: this.hashJti(jti),
+        expiresAt,
+      },
+    })
+
+    return { accessToken, refreshToken, refreshTokenMaxAgeMs: REFRESH_TTL_MS }
+  }
+
+  private hashJti(jti: string): string {
+    return crypto.createHash('sha256').update(jti).digest('hex')
   }
 }

--- a/backend/src/auth/decorators/current-refresh-user.decorator.ts
+++ b/backend/src/auth/decorators/current-refresh-user.decorator.ts
@@ -1,0 +1,14 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common'
+
+export interface RefreshUser {
+  userId: string
+  jti: string
+  token?: string
+}
+
+export const CurrentRefreshUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): RefreshUser => {
+    const request = ctx.switchToHttp().getRequest()
+    return request.user as RefreshUser
+  },
+)

--- a/backend/src/auth/guards/jwt-refresh.guard.ts
+++ b/backend/src/auth/guards/jwt-refresh.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+
+@Injectable()
+export class JwtRefreshGuard extends AuthGuard('admin-jwt-refresh') {}

--- a/backend/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/backend/src/auth/strategies/jwt-refresh.strategy.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { PassportStrategy } from '@nestjs/passport'
+import { ExtractJwt, Strategy } from 'passport-jwt'
+import { Request } from 'express'
+
+export interface JwtRefreshPayload {
+  sub: string
+  jti: string
+}
+
+export const REFRESH_COOKIE_NAME = 'admin_refresh_token'
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'admin-jwt-refresh') {
+  constructor(config: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req: Request) => req?.cookies?.[REFRESH_COOKIE_NAME] ?? null,
+      ]),
+      ignoreExpiration: false,
+      secretOrKey: config.getOrThrow<string>('JWT_ADMIN_REFRESH_SECRET'),
+      passReqToCallback: true,
+    })
+  }
+
+  validate(req: Request, payload: JwtRefreshPayload) {
+    return {
+      userId: payload.sub,
+      jti: payload.jti,
+      token: req?.cookies?.[REFRESH_COOKIE_NAME] as string | undefined,
+    }
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,21 +1,62 @@
-import axios from 'axios'
+import axios, { AxiosError, AxiosRequestConfig } from 'axios'
 
 export const api = axios.create({
   baseURL: '/api/admin',
   withCredentials: true,
 })
 
+type RetriableConfig = AxiosRequestConfig & { _retry?: boolean }
+
+const REFRESH_PATH = '/auth/refresh'
+const LOGIN_PATH = '/auth/login'
+const LOGOUT_PATH = '/auth/logout'
+const ME_PATH = '/auth/me'
+
+let refreshInFlight: Promise<void> | null = null
+
+const refreshSession = async () => {
+  if (!refreshInFlight) {
+    refreshInFlight = api.post(REFRESH_PATH).then(
+      () => undefined,
+      (err) => {
+        throw err
+      },
+    )
+    refreshInFlight.finally(() => {
+      refreshInFlight = null
+    })
+  }
+  return refreshInFlight
+}
+
+const isAuthEndpoint = (url: string) =>
+  url.includes(REFRESH_PATH) || url.includes(LOGIN_PATH) || url.includes(LOGOUT_PATH)
+
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      const url = error.config?.url ?? ''
-      const isAuthCheck = url.includes('/auth/me')
-      const onLoginPage = window.location.pathname === '/login'
-      if (!isAuthCheck && !onLoginPage) {
-        window.location.href = '/login'
+  async (error: AxiosError) => {
+    const original = error.config as RetriableConfig | undefined
+    const status = error.response?.status
+    const url = original?.url ?? ''
+    const onLoginPage = typeof window !== 'undefined' && window.location.pathname === '/login'
+
+    if (status === 401 && original && !original._retry && !isAuthEndpoint(url)) {
+      original._retry = true
+      try {
+        await refreshSession()
+        return api.request(original)
+      } catch {
+        if (!onLoginPage && !url.includes(ME_PATH)) {
+          window.location.href = '/login'
+        }
+        return Promise.reject(error)
       }
     }
+
+    if (status === 401 && !onLoginPage && !url.includes(ME_PATH) && !isAuthEndpoint(url)) {
+      window.location.href = '/login'
+    }
+
     return Promise.reject(error)
   },
 )


### PR DESCRIPTION
Closes #9

## Resumo
Implementa o fluxo de refresh token (rotação + revogação) para evitar logout abrupto após 8h.

- Login agora emite **dois** cookies httpOnly: `admin_token` (access, 8h) e `admin_refresh_token` (refresh, 7d, path=`/api/admin/auth`).
- Novo endpoint `POST /api/admin/auth/refresh` (JwtRefreshGuard) rotaciona o par: revoga a linha anterior em `admin_refresh_tokens` e emite uma nova. Reuso de um `jti` já revogado dispara revogação em massa de toda a família do usuário (detecção de roubo de token).
- Logout revoga a linha em DB antes de limpar cookies.
- Apenas o **hash sha256 do `jti`** (UUID) é persistido — o JWT em si nunca toca o banco.
- Segredo separado `JWT_ADMIN_REFRESH_SECRET` (defense in depth).

## Frontend
- Interceptor do Axios tenta `POST /auth/refresh` uma única vez ao receber 401 (com lock global p/ múltiplas requests paralelas) e replay da requisição original. Se o refresh também falhar, redireciona pra `/login`.
- Endpoints de auth (`/auth/login`, `/auth/refresh`, `/auth/logout`) ficam fora da política de retry para evitar loops.

## DB
- Nova tabela `admin_refresh_tokens` (id, user_id, token_hash unique, expires_at, revoked_at, created_at) com FK ON DELETE CASCADE para `admin_users`.
- Migration: `20260425173311_add_admin_refresh_tokens`.

## Setup necessário
Adicionar variável nova ao ambiente — `JWT_ADMIN_REFRESH_SECRET` (distinto de `JWT_ADMIN_SECRET`):
- `backend/.env.example`: já atualizado.
- `docker-compose.yml` da raiz e `.env.example` da raiz: também atualizados localmente (não ficam neste repo, ver workspace).

## Test plan
- [ ] `bun run start:dev` no backend após criar `JWT_ADMIN_REFRESH_SECRET` em `.env.dev`
- [ ] `bun run prisma:migrate:deploy` aplica a migration `20260425173311_add_admin_refresh_tokens`
- [ ] Login no painel: confere via DevTools que `admin_token` (path `/`) e `admin_refresh_token` (path `/api/admin/auth`) foram setados como httpOnly
- [ ] Apagar `admin_token` no DevTools, fazer qualquer request → frontend chama `/auth/refresh` automaticamente, novo `admin_token` aparece, sessão segue
- [ ] `POST /api/admin/auth/refresh` duas vezes com o mesmo refresh antigo → segunda chamada retorna 401 e revoga toda a família do usuário em `admin_refresh_tokens`
- [ ] Logout limpa ambos os cookies e marca a linha como `revoked_at`
- [ ] Após 8h+ (ou alterando `expiresIn` do access pra ~10s p/ teste), refresh é acionado de forma transparente