### PR TITLE
feat(organizations): rate-limit no reset de senha da clínica

### DIFF
--- a/backend/src/common/guards/admin-throttler.guard.ts
+++ b/backend/src/common/guards/admin-throttler.guard.ts
@@ -1,0 +1,26 @@
+import { ExecutionContext, Injectable, Logger } from '@nestjs/common'
+import { ThrottlerException, ThrottlerGuard, ThrottlerLimitDetail } from '@nestjs/throttler'
+import type { Request } from 'express'
+
+@Injectable()
+export class AdminThrottlerGuard extends ThrottlerGuard {
+  private readonly logger = new Logger(AdminThrottlerGuard.name)
+
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    const user = req.user as { sub?: string } | undefined
+    if (user?.sub) return `admin:${user.sub}`
+    const ip = (req.ip as string | undefined) ?? 'unknown'
+    return `ip:${ip}`
+  }
+
+  protected async throwThrottlingException(
+    context: ExecutionContext,
+    detail: ThrottlerLimitDetail,
+  ): Promise<void> {
+    const req = context.switchToHttp().getRequest<Request>()
+    this.logger.warn(
+      `Rate limit hit on ${req.method} ${req.originalUrl} for ${detail.tracker} (limit ${detail.limit}/${detail.ttl}ms)`,
+    )
+    throw new ThrottlerException()
+  }
+}

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -3,9 +3,11 @@ import {
   Body, Param, Query, UseGuards,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger'
+import { Throttle } from '@nestjs/throttler'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
+import { AdminThrottlerGuard } from '../common/guards/admin-throttler.guard'
 import { CreateOrganizationUseCase } from './application/create-organization.usecase'
 import { CreateOrganizationWithOwnerUseCase } from './application/create-organization-with-owner.usecase'
 import { UpdateOrgStatusUseCase } from './application/update-status.usecase'
@@ -116,6 +118,8 @@ export class OrganizationsController {
 
   @Post(':id/users/:organizationUserId/reset-password')
   @Roles('SUPER_ADMIN', 'SUPPORT')
+  @UseGuards(AdminThrottlerGuard)
+  @Throttle({ default: { limit: 5, ttl: 600_000 } })
   resetUserPassword(
     @Param('id') id: string,
     @Param('organizationUserId') organizationUserId: string,


### PR DESCRIPTION
## Summary
- Aplica `@Throttle({ default: { limit: 5, ttl: 600_000 } })` no endpoint `POST /organizations/:id/users/:organizationUserId/reset-password`
- Novo `AdminThrottlerGuard` (`backend/src/common/guards/admin-throttler.guard.ts`) que rastreia por `req.user.sub` (admin autenticado) com fallback pra IP — protege mesmo se o operador trocar de origem
- Loga `warn` quando o limite é atingido com método, URL e tracker

## Decisão de escopo
A issue sugere duas janelas (5/10min por admin + 20/h por IP). Implementei só a janela por admin agora — é a defesa mais forte (rastreia o ator, não a origem) e cobre o fluxo autenticado do endpoint. A janela por IP fica como follow-up se observação de uso justificar; basta acrescentar um throttler nomeado adicional.

## Test plan
- [x] `nest build` — compila limpo
- [ ] Manual: 5 resets seguidos → 6º responde 429; outros endpoints permanecem operando normalmente
- [ ] Manual: aguardar 10 min e o contador zera

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)