### PR TITLE
chore: rebrand CareFlow → Pelvi no admin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,11 @@ All development MUST follow this process — no exceptions:
 
 ## Overview
 
-CareFlow Admin is a full-stack SaaS admin dashboard for managing clinic organizations, subscription plans, billing, and metrics — the **operator back-office** of the `careflow-ui` clinic product. It consists of a React frontend (`frontend/`) and a NestJS backend (`backend/`) in separate subdirectories.
+Pelvi Admin is a full-stack SaaS admin dashboard for managing clinic organizations, subscription plans, billing, and metrics — the **operator back-office** of the `pelvi-ui` clinic product. It consists of a React frontend (`frontend/`) and a NestJS backend (`backend/`) in separate subdirectories.
 
 **Package manager**: **Bun** (`bun.lock` is the lockfile of record in both `backend/` and `frontend/`). Do not commit `package-lock.json`.
 
-See the parent `C:/Repos/Careflow/CLAUDE.md` for how this project talks to `careflow-ui` (shared `INTERNAL_API_KEY`, no cross-DB FKs — integration is HTTP-only via the `clinic-api/` module).
+See the parent `C:/Repos/Pelvi/CLAUDE.md` for how this project talks to `pelvi-ui` (shared `INTERNAL_API_KEY`, no cross-DB FKs — integration is HTTP-only via the `clinic-api/` module).
 
 ---
 
@@ -96,7 +96,7 @@ Copy `backend/.env.example` to `backend/.env.dev` and populate:
 - `JWT_ADMIN_SECRET` — JWT signing secret
 - `PORT` — Backend port (default 3001)
 - `CORS_ORIGIN` — Frontend URL for CORS (required in production)
-- `CLINIC_API_URL` — Base URL of the careflow-ui clinic API (e.g. `http://localhost:3000`). The admin appends `/api/internal/*` — do **not** include the path prefix in this value.
+- `CLINIC_API_URL` — Base URL of the pelvi-ui clinic API (e.g. `http://localhost:3000`). The admin appends `/api/internal/*` — do **not** include the path prefix in this value.
 - `CLINIC_INTERNAL_API_KEY` — Shared secret for clinic API requests. Must match `INTERNAL_API_KEY` on the clinic side.
 
 ### Docker
@@ -151,7 +151,7 @@ Login issues the cookie server-side; logout clears it.
 
 **Admin roles**: `SUPER_ADMIN`, `FINANCE`, `SUPPORT` — defined in Prisma schema and `types/admin.ts`.
 
-**External integration (`clinic-api/`)**: the `ClinicApiService` is the single seam that talks to the careflow-ui clinic backend over HTTP using the shared `CLINIC_INTERNAL_API_KEY` header. It:
+**External integration (`clinic-api/`)**: the `ClinicApiService` is the single seam that talks to the pelvi-ui clinic backend over HTTP using the shared `CLINIC_INTERNAL_API_KEY` header. It:
 - Appends `/api/internal/*` to `CLINIC_API_URL` — the clinic product sets a `/api` global prefix, so do **not** call `/internal/*` directly.
 - Builds outbound URLs via a `buildUrl` tagged-template helper that `encodeURIComponent`-s every dynamic segment and asserts the final `URL.origin` matches the configured base — this blocks SSRF / path-traversal when ids come from HTTP params.
 - Supported operations: clinic create/list, access update, **person upsert**, **link person to clinic (ADMIN/PROFESSIONAL/RECEPTIONIST)**, **list/update/reset-password clinic users**.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,10 @@
-DATABASE_ADMIN_URL="postgresql://user:password@host:5432/careflow_admin"
+DATABASE_ADMIN_URL="postgresql://user:password@host:5432/pelvi_admin"
 JWT_ADMIN_SECRET="your-strong-secret-here"
 JWT_ADMIN_REFRESH_SECRET="another-strong-secret-distinct-from-the-access-secret"
 PORT=3001
 CORS_ORIGIN="https://your-admin-frontend-url.com"
 NODE_ENV="production"
-CLINIC_API_URL="https://api.careflow.com.br"
+CLINIC_API_URL="https://api.soupelvi.com.br"
 # CLINIC_INTERNAL_API_KEY — shared secret used in x-internal-api-key header for machine-to-machine calls.
 # Rotation policy: rotate every 90 days or immediately upon suspected compromise.
 # Steps: generate a new high-entropy secret (min 32 chars), update both services simultaneously,

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,11 +40,11 @@ ENV APP_VERSION=$APP_VERSION \
     GIT_SHA=$GIT_SHA \
     BUILT_AT=$BUILT_AT
 
-LABEL org.opencontainers.image.title="careflow-admin-api" \
+LABEL org.opencontainers.image.title="pelvi-admin-api" \
       org.opencontainers.image.version=$APP_VERSION \
       org.opencontainers.image.revision=$GIT_SHA \
       org.opencontainers.image.created=$BUILT_AT \
-      org.opencontainers.image.source="https://github.com/brav-lima/careflow-admin"
+      org.opencontainers.image.source="https://github.com/brav-lima/pelvi-admin"
 
 EXPOSE 3001
 

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "careflow-admin-api",
+      "name": "pelvi-admin-api",
       "dependencies": {
         "@nestjs/common": "^11.1.18",
         "@nestjs/config": "^4.0.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "careflow-admin-api",
+  "name": "pelvi-admin-api",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -70,7 +70,7 @@ model Organization {
   email      String
   phone      String?
   status     OrgStatus @default(ACTIVE)
-  clinicExternalId String? @map("clinic_external_id") // ID da Clinic no careflow (sem FK cross-db)
+  clinicExternalId String? @map("clinic_external_id") // ID da Clinic no pelvi-ui (sem FK cross-db)
   createdAt  DateTime  @default(now()) @map("created_at")
   updatedAt  DateTime  @updatedAt @map("updated_at")
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -42,7 +42,7 @@ async function main() {
   console.log(`✅ ${plans.length} planos criados`)
 
   // Super admin inicial
-  const adminEmail = process.env.SEED_ADMIN_EMAIL ?? 'admin@careflow.com.br'
+  const adminEmail = process.env.SEED_ADMIN_EMAIL ?? 'admin@soupelvi.com.br'
   const adminPassword = process.env.SEED_ADMIN_PASSWORD ?? 'changeme123'
 
   const passwordHash = await bcrypt.hash(adminPassword, 12)

--- a/backend/src/auth/dto/create-admin.dto.ts
+++ b/backend/src/auth/dto/create-admin.dto.ts
@@ -7,7 +7,7 @@ export class CreateAdminDto {
   @IsString()
   name: string
 
-  @ApiProperty({ example: 'joao@careflow.com.br' })
+  @ApiProperty({ example: 'joao@soupelvi.com.br' })
   @IsEmail()
   email: string
 

--- a/backend/src/clinic-api/clinic-api.service.ts
+++ b/backend/src/clinic-api/clinic-api.service.ts
@@ -110,7 +110,7 @@ export class ClinicApiService {
     const base = new URL(this.baseUrl)
     const url = new URL(base.toString().replace(/\/+$/, '') + path)
     if (url.origin !== base.origin) {
-      throw new ServiceUnavailableException('URL inválida para careflow API')
+      throw new ServiceUnavailableException('URL inválida para pelvi API')
     }
     return url.toString()
   }
@@ -122,7 +122,7 @@ export class ClinicApiService {
       const res = await fetch(url, { ...options, signal: controller.signal })
       return res
     } catch {
-      throw new ServiceUnavailableException('careflow API indisponível')
+      throw new ServiceUnavailableException('pelvi API indisponível')
     } finally {
       clearTimeout(timeout)
     }
@@ -140,14 +140,14 @@ export class ClinicApiService {
     if (!res.ok) {
       const body = await res.text()
       this.logger.error(`createClinic failed [${res.status}]: ${body}`)
-      throw new ServiceUnavailableException(`Erro ao criar clínica no careflow: ${res.status}`)
+      throw new ServiceUnavailableException(`Erro ao criar clínica no pelvi: ${res.status}`)
     }
 
     return res.json() as Promise<CreateClinicResponse>
   }
 
   async listClinics(): Promise<ClinicSummary[]> {
-    this.logger.log('Listing clinics from careflow')
+    this.logger.log('Listing clinics from pelvi')
 
     const res = await this.fetchWithTimeout(this.buildUrl`/api/internal/clinics`, {
       method: 'GET',
@@ -157,7 +157,7 @@ export class ClinicApiService {
     if (!res.ok) {
       const body = await res.text()
       this.logger.error(`listClinics failed [${res.status}]: ${body}`)
-      throw new ServiceUnavailableException(`Erro ao listar clínicas do careflow: ${res.status}`)
+      throw new ServiceUnavailableException(`Erro ao listar clínicas do pelvi: ${res.status}`)
     }
 
     return res.json() as Promise<ClinicSummary[]>
@@ -182,7 +182,7 @@ export class ClinicApiService {
     if (!res.ok) {
       const body = await res.text()
       this.logger.error(`updateClinicAccess failed [${res.status}]: ${body}`)
-      throw new ServiceUnavailableException(`Erro ao atualizar acesso no careflow: ${res.status}`)
+      throw new ServiceUnavailableException(`Erro ao atualizar acesso no pelvi: ${res.status}`)
     }
   }
 
@@ -198,7 +198,7 @@ export class ClinicApiService {
     if (!res.ok) {
       const body = await res.text()
       this.logger.error(`upsertPerson failed [${res.status}]: ${body}`)
-      throw new ServiceUnavailableException(`Erro ao registrar responsável no careflow: ${res.status}`)
+      throw new ServiceUnavailableException(`Erro ao registrar responsável no pelvi: ${res.status}`)
     }
 
     return res.json() as Promise<UpsertPersonResponse>

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -35,8 +35,8 @@ async function bootstrap() {
   app.setGlobalPrefix('api/admin')
 
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('CareFlow Admin API')
-    .setDescription('API interna de gestão SaaS do CareFlow')
+    .setTitle('Pelvi Admin API')
+    .setDescription('API interna de gestão SaaS do Pelvi')
     .setVersion('1.0')
     .addBearerAuth()
     .build()

--- a/backend/src/organizations/application/create-organization.usecase.ts
+++ b/backend/src/organizations/application/create-organization.usecase.ts
@@ -8,7 +8,7 @@ export interface CreateOrganizationInput {
   document: string
   email: string
   phone?: string
-  // Se fornecido, vincula a uma clínica já existente no careflow (não cria nova)
+  // Se fornecido, vincula a uma clínica já existente no pelvi-ui (não cria nova)
   clinicExternalId?: string
 }
 
@@ -29,7 +29,7 @@ export class CreateOrganizationUseCase {
     let clinicExternalId = input.clinicExternalId ?? null
 
     if (!clinicExternalId) {
-      // Cria a clínica no careflow e obtém o ID externo
+      // Cria a clínica no pelvi-ui e obtém o ID externo
       const clinic = await this.clinicApi.createClinic({
         name: input.name,
         document: input.document,

--- a/backend/src/organizations/application/resolve-clinic-id.ts
+++ b/backend/src/organizations/application/resolve-clinic-id.ts
@@ -12,7 +12,7 @@ export class ResolveClinicId {
     const org = await this.repo.findById(organizationId)
     if (!org) throw new NotFoundException('Organização não encontrada')
     if (!org.clinicExternalId) {
-      throw new BadRequestException('Organização não está vinculada a uma clínica no careflow')
+      throw new BadRequestException('Organização não está vinculada a uma clínica no pelvi-ui')
     }
     return org.clinicExternalId
   }

--- a/backend/src/organizations/dto/create-organization.dto.ts
+++ b/backend/src/organizations/dto/create-organization.dto.ts
@@ -21,7 +21,7 @@ export class CreateOrganizationDto {
   @IsString()
   phone?: string
 
-  @ApiPropertyOptional({ description: 'ID de uma Clinic já existente no careflow (para vincular sem criar nova)' })
+  @ApiPropertyOptional({ description: 'ID de uma Clinic já existente no pelvi-ui (para vincular sem criar nova)' })
   @IsOptional()
   @IsString()
   clinicExternalId?: string

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -42,7 +42,7 @@ export class SubscriptionsService {
       include: { plan: true, organization: true },
     })
 
-    // Propaga limites do plano ao careflow-ui
+    // Propaga limites do plano ao pelvi-ui
     if (subscription.organization.clinicExternalId) {
       await this.clinicApi.updateClinicAccess(
         subscription.organization.clinicExternalId,

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,11 +23,11 @@ FROM nginx:alpine AS runner
 ARG APP_VERSION=dev
 ARG GIT_SHA=unknown
 ARG BUILT_AT=unknown
-LABEL org.opencontainers.image.title="careflow-admin-web" \
+LABEL org.opencontainers.image.title="pelvi-admin-web" \
       org.opencontainers.image.version=$APP_VERSION \
       org.opencontainers.image.revision=$GIT_SHA \
       org.opencontainers.image.created=$BUILT_AT \
-      org.opencontainers.image.source="https://github.com/brav-lima/careflow-admin"
+      org.opencontainers.image.source="https://github.com/brav-lima/pelvi-admin"
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "careflow-admin-web",
+      "name": "pelvi-admin-web",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-avatar": "^1.1.1",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CareFlow Admin</title>
+    <title>Pelvi Admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://careflow-admin-api:3001;
+        proxy_pass http://pelvi-admin-api:3001;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "careflow-admin-web",
+  "name": "pelvi-admin-web",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/frontend/src/components/layout/AdminSidebar.tsx
+++ b/frontend/src/components/layout/AdminSidebar.tsx
@@ -15,7 +15,7 @@ export function AdminSidebar() {
   return (
     <aside className="w-60 bg-sidebar text-sidebar-foreground flex flex-col">
       <div className="px-6 py-5 border-b border-sidebar-border">
-        <h1 className="text-lg font-semibold text-sidebar-foreground">CareFlow Admin</h1>
+        <h1 className="text-lg font-semibold text-sidebar-foreground">Pelvi Admin</h1>
         <p className="text-xs text-sidebar-foreground/60 mt-0.5">Gestão SaaS</p>
       </div>
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -28,7 +28,7 @@ export function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-muted/40">
       <div className="w-full max-w-sm bg-card rounded-lg border p-8 shadow-sm">
         <div className="mb-6">
-          <h1 className="text-2xl font-bold">CareFlow Admin</h1>
+          <h1 className="text-2xl font-bold">Pelvi Admin</h1>
           <p className="text-muted-foreground text-sm mt-1">Gestão interna SaaS</p>
         </div>
 
@@ -40,7 +40,7 @@ export function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className="w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-              placeholder="admin@careflow.com.br"
+              placeholder="admin@soupelvi.com.br"
               required
             />
           </div>


### PR DESCRIPTION
## Resumo

- Título da página de login alterado de "CareFlow Admin" para "Pelvi Admin"
- Mensagens de erro e logs do `ClinicApiService` renomeados de "careflow" para "pelvi"
- Swagger, metadados Docker, `package.json`, `bun.lock` e `CLAUDE.md` atualizados

## Plano de testes

- [ ] Acessar `/login` e verificar o título "Pelvi Admin"
- [ ] Verificar que `GET /api/admin/docs` exibe o novo título
- [ ] Simular erro de comunicação com a API da clínica e confirmar mensagem menciona "pelvi"

🤖 Generated with [Claude Code](https://claude.com/claude-code)