### PR TITLE
feat: org criada com subscription TRIAL de 14 dias

### DIFF
--- a/backend/src/organizations/application/create-organization-with-owner.usecase.spec.ts
+++ b/backend/src/organizations/application/create-organization-with-owner.usecase.spec.ts
@@ -5,6 +5,8 @@ import {
 } from './create-organization-with-owner.usecase'
 import { IOrganizationRepository } from '../domain/organization.repository'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
+import { PrismaService } from '../../prisma/prisma.service'
+import { ResolveTrialPlan } from './resolve-trial-plan'
 import { Organization } from '../domain/organization.entity'
 
 const makeOrg = (overrides: Partial<Organization> = {}): Organization => ({
@@ -18,6 +20,12 @@ const makeOrg = (overrides: Partial<Organization> = {}): Organization => ({
   createdAt: new Date(),
   updatedAt: new Date(),
   ...overrides,
+})
+
+const makeSub = () => ({
+  id: 'sub-1',
+  status: 'TRIAL',
+  trialEndsAt: new Date(Date.now() + 14 * 86400000),
 })
 
 const baseInput: CreateOrganizationWithOwnerInput = {
@@ -46,6 +54,8 @@ const personResp = (reused = false) => ({
 describe('CreateOrganizationWithOwnerUseCase', () => {
   let repo: jest.Mocked<IOrganizationRepository>
   let clinicApi: jest.Mocked<ClinicApiService>
+  let prisma: jest.Mocked<Pick<PrismaService, 'subscription' | 'plan'>>
+  let resolveTrialPlan: jest.Mocked<ResolveTrialPlan>
   let sut: CreateOrganizationWithOwnerUseCase
 
   beforeEach(() => {
@@ -66,7 +76,18 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
       updateClinicUser: jest.fn(),
       resetClinicUserPassword: jest.fn(),
     } as any
-    sut = new CreateOrganizationWithOwnerUseCase(repo as any, clinicApi)
+    prisma = {
+      subscription: { create: jest.fn().mockResolvedValue(makeSub()) } as any,
+      plan: { findUniqueOrThrow: jest.fn().mockResolvedValue({ maxUsers: 5, maxPatients: 100 }) } as any,
+    }
+    resolveTrialPlan = { planId: jest.fn().mockResolvedValue('plan-trial-id') } as any
+
+    sut = new CreateOrganizationWithOwnerUseCase(
+      repo as any,
+      clinicApi,
+      prisma as any,
+      resolveTrialPlan,
+    )
   })
 
   it('throws ConflictException when document already belongs to an org', async () => {
@@ -83,15 +104,43 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
 
     await sut.execute(baseInput)
 
-    const callOrder = [
-      clinicApi.createClinic,
-      clinicApi.upsertPerson,
-      clinicApi.linkPersonToClinic,
-      repo.create,
-    ]
-    for (let i = 0; i < callOrder.length - 1; i++) {
-      expect(callOrder[i]).toHaveBeenCalled()
-    }
+    expect(clinicApi.createClinic).toHaveBeenCalled()
+    expect(clinicApi.upsertPerson).toHaveBeenCalled()
+    expect(clinicApi.linkPersonToClinic).toHaveBeenCalled()
+    expect(repo.create).toHaveBeenCalled()
+    expect(prisma.subscription.create).toHaveBeenCalled()
+  })
+
+  it('creates TRIAL subscription with 14-day trialEndsAt', async () => {
+    repo.findAll.mockResolvedValue({ data: [], total: 0 })
+    clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
+    clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
+    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
+    repo.create.mockResolvedValue(makeOrg({ id: 'org-new' }))
+
+    await sut.execute(baseInput)
+
+    expect(prisma.subscription.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organizationId: 'org-new',
+          planId: 'plan-trial-id',
+          status: 'TRIAL',
+        }),
+      }),
+    )
+  })
+
+  it('returns subscription info in result', async () => {
+    repo.findAll.mockResolvedValue({ data: [], total: 0 })
+    clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
+    clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
+    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
+    repo.create.mockResolvedValue(makeOrg())
+
+    const result = await sut.execute(baseInput)
+
+    expect(result.subscription).toMatchObject({ id: 'sub-1', status: 'TRIAL' })
   })
 
   it('returns provisionalPassword when person is newly created', async () => {

--- a/backend/src/organizations/application/create-organization-with-owner.usecase.ts
+++ b/backend/src/organizations/application/create-organization-with-owner.usecase.ts
@@ -2,6 +2,8 @@ import { ConflictException, Inject, Injectable, Logger } from '@nestjs/common'
 import { IOrganizationRepository, ORGANIZATION_REPOSITORY } from '../domain/organization.repository'
 import { Organization } from '../domain/organization.entity'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
+import { PrismaService } from '../../prisma/prisma.service'
+import { ResolveTrialPlan } from './resolve-trial-plan'
 import { generateProvisionalPassword } from './provisional-password'
 
 export interface CreateOrganizationWithOwnerInput {
@@ -26,9 +28,16 @@ export interface CreateOrganizationWithOwnerResult {
     email: string
     reused: boolean
   }
+  subscription: {
+    id: string
+    status: string
+    trialEndsAt: Date
+  }
   // Retornado apenas quando a pessoa foi criada agora. UI deve exibir uma única vez.
   provisionalPassword: string | null
 }
+
+const TRIAL_DAYS = 14
 
 @Injectable()
 export class CreateOrganizationWithOwnerUseCase {
@@ -38,6 +47,8 @@ export class CreateOrganizationWithOwnerUseCase {
     @Inject(ORGANIZATION_REPOSITORY)
     private readonly repo: IOrganizationRepository,
     private readonly clinicApi: ClinicApiService,
+    private readonly prisma: PrismaService,
+    private readonly resolveTrialPlan: ResolveTrialPlan,
   ) {}
 
   async execute(input: CreateOrganizationWithOwnerInput): Promise<CreateOrganizationWithOwnerResult> {
@@ -77,10 +88,29 @@ export class CreateOrganizationWithOwnerUseCase {
       clinicExternalId: clinic.clinicId,
     })
 
+    // Toda org nasce com subscription TRIAL de 14 dias
+    const trialPlanId = await this.resolveTrialPlan.planId()
+    const trialEndsAt = new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000)
+
+    const subscription = await this.prisma.subscription.create({
+      data: {
+        organizationId: organization.id,
+        planId: trialPlanId,
+        status: 'TRIAL',
+        startDate: new Date(),
+        trialEndsAt,
+      },
+    })
+
+    // Propaga limites do plano ao pelvi-ui
+    const plan = await this.prisma.plan.findUniqueOrThrow({ where: { id: trialPlanId } })
+    await this.clinicApi.updateClinicAccess(clinic.clinicId, 'ACTIVE', {
+      maxUsers: plan.maxUsers,
+      maxPatients: plan.maxPatients,
+    })
+
     if (personResp.reused) {
-      this.logger.log(
-        `Owner reaproveitado (cpf=${input.owner.cpf}); senha provisória não foi redefinida.`,
-      )
+      this.logger.log(`Owner reaproveitado (cpf=${input.owner.cpf}); senha provisória não foi redefinida.`)
     }
 
     return {
@@ -91,6 +121,11 @@ export class CreateOrganizationWithOwnerUseCase {
         name: personResp.person.name,
         email: personResp.person.email,
         reused: personResp.reused,
+      },
+      subscription: {
+        id: subscription.id,
+        status: subscription.status,
+        trialEndsAt: subscription.trialEndsAt!,
       },
       provisionalPassword: personResp.reused ? null : provisionalPassword,
     }

--- a/backend/src/organizations/application/resolve-trial-plan.ts
+++ b/backend/src/organizations/application/resolve-trial-plan.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { PrismaService } from '../../prisma/prisma.service'
+
+@Injectable()
+export class ResolveTrialPlan {
+  private readonly logger = new Logger(ResolveTrialPlan.name)
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async planId(): Promise<string> {
+    const fromEnv = this.config.get<string>('TRIAL_PLAN_ID')
+    if (fromEnv) return fromEnv
+
+    const plan = await this.prisma.plan.findFirst({
+      where: { name: { contains: 'Trial', mode: 'insensitive' }, isActive: true },
+    })
+
+    if (!plan) {
+      this.logger.warn('Nenhum plano de trial encontrado. Configure TRIAL_PLAN_ID ou crie um plano com nome "Trial".')
+      throw new Error('Plano de trial não encontrado. Configure TRIAL_PLAN_ID.')
+    }
+
+    return plan.id
+  }
+}

--- a/backend/src/organizations/organizations.module.ts
+++ b/backend/src/organizations/organizations.module.ts
@@ -6,6 +6,7 @@ import { UpdateOrgStatusUseCase } from './application/update-status.usecase'
 import { ListOrganizationsUseCase } from './application/list-organizations.usecase'
 import { ResetClinicUserPasswordUseCase } from './application/reset-clinic-user-password.usecase'
 import { ResolveClinicId } from './application/resolve-clinic-id'
+import { ResolveTrialPlan } from './application/resolve-trial-plan'
 import { PrismaOrganizationRepository } from './infra/prisma-organization.repository'
 import { ORGANIZATION_REPOSITORY } from './domain/organization.repository'
 
@@ -18,6 +19,7 @@ import { ORGANIZATION_REPOSITORY } from './domain/organization.repository'
     ListOrganizationsUseCase,
     ResetClinicUserPasswordUseCase,
     ResolveClinicId,
+    ResolveTrialPlan,
     {
       provide: ORGANIZATION_REPOSITORY,
       useClass: PrismaOrganizationRepository,


### PR DESCRIPTION
## Summary
- Toda org agora nasce com subscription TRIAL automática (14 dias) ao ser criada via `CreateOrganizationWithOwnerUseCase`
- Novo helper `ResolveTrialPlan` resolve o planId via `TRIAL_PLAN_ID` env var ou fallback por nome no banco
- Limites do plano propagados ao pelvi-ui via `updateClinicAccess` na criação
- Resultado do use case inclui dados da subscription criada

## Test plan
- [x] 7 testes unitários passando (incluindo 2 novos: criação da sub e verificação do resultado)
- [ ] Configurar `TRIAL_PLAN_ID` no `.env.dev` ou criar plano com nome "Trial" no banco antes de testar manualmente

Closes #52