### PR TITLE
fix: cascade delete and unique constraint on subscriptions

### DIFF
--- a/backend/prisma/migrations/20260508120000_subscription_cascade_and_unique/migration.sql
+++ b/backend/prisma/migrations/20260508120000_subscription_cascade_and_unique/migration.sql
@@ -1,0 +1,14 @@
+-- #10: cascade delete Subscription → Organization, Invoice → Subscription
+ALTER TABLE "subscriptions" DROP CONSTRAINT IF EXISTS "subscriptions_organization_id_fkey";
+ALTER TABLE "subscriptions"
+  ADD CONSTRAINT "subscriptions_organization_id_fkey"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE;
+
+ALTER TABLE "invoices" DROP CONSTRAINT IF EXISTS "invoices_subscription_id_fkey";
+ALTER TABLE "invoices"
+  ADD CONSTRAINT "invoices_subscription_id_fkey"
+  FOREIGN KEY ("subscription_id") REFERENCES "subscriptions"("id") ON DELETE CASCADE;
+
+-- #11: unique constraint (organization_id, plan_id) on subscriptions
+CREATE UNIQUE INDEX "subscriptions_organization_id_plan_id_key"
+  ON "subscriptions"("organization_id", "plan_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -122,11 +122,11 @@ model Subscription {
   createdAt      DateTime           @default(now()) @map("created_at")
   updatedAt      DateTime           @updatedAt @map("updated_at")
 
-  organization Organization @relation(fields: [organizationId], references: [id])
-  plan         Plan         @relation(fields: [planId], references: [id])
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  plan         Plan         @relation(fields: [planId], references: [id], onDelete: Restrict)
   invoices     Invoice[]
 
-  @@index([organizationId])
+  @@unique([organizationId, planId])
   @@index([planId])
   @@index([status])
   @@map("subscriptions")
@@ -155,7 +155,7 @@ model Invoice {
   createdAt         DateTime      @default(now()) @map("created_at")
   updatedAt         DateTime      @updatedAt @map("updated_at")
 
-  subscription Subscription @relation(fields: [subscriptionId], references: [id])
+  subscription Subscription @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
 
   @@index([subscriptionId])
   @@index([status])


### PR DESCRIPTION
## Summary
- `Subscription → Organization`: `onDelete: Cascade` — deleting an org removes its subscriptions
- `Invoice → Subscription`: `onDelete: Cascade` — deleting a subscription removes its invoices
- `Plan → Subscription`: `onDelete: Restrict` — prevents plan deletion while subscriptions exist
- `@@unique([organizationId, planId])` on `Subscription` — prevents duplicate plan per org

## Migration
`20260508120000_subscription_cascade_and_unique` — drops and recreates FK constraints with cascade rules, adds unique index.

Closes #10
Closes #11