### PR TITLE
feat: add pagination to findMany queries

### DIFF
--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -25,13 +25,24 @@ export class InvoicesController {
   @ApiQuery({ name: 'status', required: false })
   @ApiQuery({ name: 'month', required: false, type: Number })
   @ApiQuery({ name: 'year', required: false, type: Number })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
   findAll(
     @Query('subscriptionId') subscriptionId?: string,
     @Query('status') status?: string,
-    @Query('month') month?: number,
-    @Query('year') year?: number,
+    @Query('month') month?: string,
+    @Query('year') year?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
   ) {
-    return this.invoicesService.findAll(subscriptionId, status, Number(month), Number(year))
+    return this.invoicesService.findAll(
+      subscriptionId,
+      status,
+      month ? Number(month) : undefined,
+      year ? Number(year) : undefined,
+      page ? Number(page) : undefined,
+      limit ? Number(limit) : undefined,
+    )
   }
 
   @Get(':id')

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -6,7 +6,16 @@ import { CreateInvoiceDto } from './dto/create-invoice.dto'
 export class InvoicesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  findAll(subscriptionId?: string, status?: string, month?: number, year?: number) {
+  async findAll(
+    subscriptionId?: string,
+    status?: string,
+    month?: number,
+    year?: number,
+    page = 1,
+    limit = 50,
+  ) {
+    const take = Math.min(limit, 100)
+    const skip = (page - 1) * take
     const where: any = {
       ...(subscriptionId && { subscriptionId }),
       ...(status && { status }),
@@ -18,11 +27,18 @@ export class InvoicesService {
       where.dueDate = { gte: start, lte: end }
     }
 
-    return this.prisma.invoice.findMany({
-      where,
-      include: { subscription: { include: { organization: true, plan: true } } },
-      orderBy: { dueDate: 'desc' },
-    })
+    const [data, total] = await this.prisma.$transaction([
+      this.prisma.invoice.findMany({
+        where,
+        include: { subscription: { include: { organization: true, plan: true } } },
+        orderBy: { dueDate: 'desc' },
+        take,
+        skip,
+      }),
+      this.prisma.invoice.count({ where }),
+    ])
+
+    return { data, total, page, limit: take }
   }
 
   async findOne(id: string) {

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -6,35 +6,22 @@ export class MetricsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async getSummary() {
-    const [
-      activeOrgs,
-      trialOrgs,
-      suspendedOrgs,
-      activeSubscriptions,
-      overdueInvoices,
-    ] = await this.prisma.$transaction([
-      this.prisma.organization.count({ where: { status: 'ACTIVE' } }),
-      this.prisma.subscription.count({ where: { status: 'TRIAL' } }),
-      this.prisma.organization.count({ where: { status: 'SUSPENDED' } }),
-      this.prisma.subscription.findMany({
-        where: { status: 'ACTIVE' },
-        include: { plan: { select: { priceMonthly: true } } },
-      }),
-      this.prisma.invoice.count({ where: { status: 'OVERDUE' } }),
-    ])
+    const [activeOrgs, trialOrgs, suspendedOrgs, overdueInvoices, mrrAgg] =
+      await this.prisma.$transaction([
+        this.prisma.organization.count({ where: { status: 'ACTIVE' } }),
+        this.prisma.subscription.count({ where: { status: 'TRIAL' } }),
+        this.prisma.organization.count({ where: { status: 'SUSPENDED' } }),
+        this.prisma.invoice.count({ where: { status: 'OVERDUE' } }),
+        this.prisma.subscription.findMany({
+          where: { status: 'ACTIVE' },
+          select: { plan: { select: { priceMonthly: true } } },
+          take: 10000,
+        }),
+      ])
 
-    const mrr = activeSubscriptions.reduce(
-      (sum, sub) => sum + Number(sub.plan.priceMonthly),
-      0,
-    )
+    const mrr = mrrAgg.reduce((sum, sub) => sum + Number(sub.plan.priceMonthly), 0)
 
-    return {
-      mrr,
-      activeOrgs,
-      trialOrgs,
-      suspendedOrgs,
-      overdueInvoices,
-    }
+    return { mrr, activeOrgs, trialOrgs, suspendedOrgs, overdueInvoices }
   }
 
   async getRevenueByYear(year: number) {
@@ -47,6 +34,7 @@ export class MetricsService {
         },
       },
       select: { amount: true, paidAt: true },
+      take: 10000,
     })
 
     const monthly = Array.from({ length: 12 }, (_, i) => ({
@@ -74,6 +62,7 @@ export class MetricsService {
       where: { createdAt: { gte: ranges[period] } },
       select: { id: true, name: true, status: true, createdAt: true },
       orderBy: { createdAt: 'desc' },
+      take: 500,
     })
   }
 }

--- a/backend/src/subscriptions/subscriptions.controller.ts
+++ b/backend/src/subscriptions/subscriptions.controller.ts
@@ -23,8 +23,20 @@ export class SubscriptionsController {
   @Roles('SUPER_ADMIN', 'FINANCE')
   @ApiQuery({ name: 'orgId', required: false })
   @ApiQuery({ name: 'status', required: false })
-  findAll(@Query('orgId') orgId?: string, @Query('status') status?: string) {
-    return this.subscriptionsService.findAll(orgId, status)
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  findAll(
+    @Query('orgId') orgId?: string,
+    @Query('status') status?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.subscriptionsService.findAll(
+      orgId,
+      status,
+      page ? Number(page) : undefined,
+      limit ? Number(limit) : undefined,
+    )
   }
 
   @Get(':id')

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -10,15 +10,26 @@ export class SubscriptionsService {
     private readonly clinicApi: ClinicApiService,
   ) {}
 
-  findAll(orgId?: string, status?: string) {
-    return this.prisma.subscription.findMany({
-      where: {
-        ...(orgId && { organizationId: orgId }),
-        ...(status && { status: status as any }),
-      },
-      include: { plan: true, organization: true },
-      orderBy: { createdAt: 'desc' },
-    })
+  async findAll(orgId?: string, status?: string, page = 1, limit = 50) {
+    const take = Math.min(limit, 100)
+    const skip = (page - 1) * take
+    const where = {
+      ...(orgId && { organizationId: orgId }),
+      ...(status && { status: status as any }),
+    }
+
+    const [data, total] = await this.prisma.$transaction([
+      this.prisma.subscription.findMany({
+        where,
+        include: { plan: true, organization: true },
+        orderBy: { createdAt: 'desc' },
+        take,
+        skip,
+      }),
+      this.prisma.subscription.count({ where }),
+    ])
+
+    return { data, total, page, limit: take }
   }
 
   async findOne(id: string) {

--- a/frontend/src/pages/Invoices.tsx
+++ b/frontend/src/pages/Invoices.tsx
@@ -17,10 +17,11 @@ export function InvoicesPage() {
   const queryClient = useQueryClient()
   const { toast } = useToast()
 
-  const { data: invoices, isLoading } = useQuery<Invoice[]>({
+  const { data: invoicesResp, isLoading } = useQuery<{ data: Invoice[]; total: number }>({
     queryKey: ['invoices'],
     queryFn: () => api.get('/invoices').then((r) => r.data),
   })
+  const invoices = invoicesResp?.data
 
   const markPaid = useMutation({
     mutationFn: (id: string) => api.patch(`/invoices/${id}/mark-paid`),

--- a/frontend/src/pages/OrganizationDetail.tsx
+++ b/frontend/src/pages/OrganizationDetail.tsx
@@ -25,22 +25,24 @@ export function OrganizationDetailPage() {
     queryFn: () => api.get(`/organizations/${id}`).then((r) => r.data),
   })
 
-  const { data: subscriptions } = useQuery<Subscription[]>({
+  const { data: subscriptionsResp } = useQuery<{ data: Subscription[]; total: number }>({
     queryKey: ['subscriptions', id],
     queryFn: () => api.get('/subscriptions', { params: { orgId: id } }).then((r) => r.data),
     enabled: !!id,
   })
+  const subscriptions = subscriptionsResp?.data
 
   const activeSubscription = subscriptions?.find(
     (s) => s.status === 'ACTIVE' || s.status === 'TRIAL',
   )
 
-  const { data: invoices } = useQuery<Invoice[]>({
+  const { data: invoicesResp } = useQuery<{ data: Invoice[]; total: number }>({
     queryKey: ['invoices', activeSubscription?.id],
     queryFn: () =>
       api.get('/invoices', { params: { subscriptionId: activeSubscription!.id } }).then((r) => r.data),
     enabled: !!activeSubscription,
   })
+  const invoices = invoicesResp?.data
 
   const changeStatus = useMutation({
     mutationFn: (status: OrgStatus) => api.patch(`/organizations/${id}/status`, { status }),

--- a/frontend/src/pages/Subscriptions.tsx
+++ b/frontend/src/pages/Subscriptions.tsx
@@ -13,10 +13,11 @@ const statusLabel: Record<SubscriptionStatus, { label: string; className: string
 }
 
 export function SubscriptionsPage() {
-  const { data: subscriptions, isLoading } = useQuery<Subscription[]>({
+  const { data: subscriptionsResp, isLoading } = useQuery<{ data: Subscription[]; total: number }>({
     queryKey: ['subscriptions'],
     queryFn: () => api.get('/subscriptions').then((r) => r.data),
   })
+  const subscriptions = subscriptionsResp?.data
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- `GET /invoices` and `GET /subscriptions` now accept `page` and `limit` query params (default: page=1, limit=50, max=100)
- Response shape: `{ data: T[], total: number, page: number, limit: number }`
- Metrics service `findMany` calls capped to prevent unbounded memory growth
- Frontend updated to consume new paginated response shape

Closes #5