### PR TITLE
fix: add error state handling to React Query hooks

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { TrendingUp, Building2, Clock, AlertTriangle, Ban } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 
 export function DashboardPage() {
-  const { data, isLoading } = useQuery<MetricsSummary>({
+  const { data, isLoading, error } = useQuery<MetricsSummary>({
     queryKey: ['metrics-summary'],
     queryFn: () => api.get('/metrics/summary').then((r) => r.data),
   })
@@ -23,6 +23,14 @@ export function DashboardPage() {
             </div>
           ))}
         </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Falha ao carregar métricas. Tente novamente.
       </div>
     )
   }

--- a/frontend/src/pages/Invoices.tsx
+++ b/frontend/src/pages/Invoices.tsx
@@ -17,7 +17,7 @@ export function InvoicesPage() {
   const queryClient = useQueryClient()
   const { toast } = useToast()
 
-  const { data: invoices, isLoading } = useQuery<Invoice[]>({
+  const { data: invoices, isLoading, error } = useQuery<Invoice[]>({
     queryKey: ['invoices'],
     queryFn: () => api.get('/invoices').then((r) => r.data),
   })
@@ -64,6 +64,14 @@ export function InvoicesPage() {
             </tbody>
           </table>
         </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Falha ao carregar faturas. Tente novamente.
       </div>
     )
   }

--- a/frontend/src/pages/Organizations.tsx
+++ b/frontend/src/pages/Organizations.tsx
@@ -17,7 +17,7 @@ export function OrganizationsPage() {
   const [search, setSearch] = useState('')
   const [status, setStatus] = useState<OrgStatus | ''>('')
 
-  const { data, isLoading } = useQuery<PaginatedResponse<Organization>>({
+  const { data, isLoading, error } = useQuery<PaginatedResponse<Organization>>({
     queryKey: ['organizations', search, status],
     queryFn: () =>
       api
@@ -51,6 +51,12 @@ export function OrganizationsPage() {
           <option value="CANCELED">Cancelada</option>
         </select>
       </div>
+
+      {error && (
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          Falha ao carregar organizações. Tente novamente.
+        </div>
+      )}
 
       {isLoading ? (
         <div className="border rounded-lg overflow-hidden">

--- a/frontend/src/pages/Subscriptions.tsx
+++ b/frontend/src/pages/Subscriptions.tsx
@@ -13,7 +13,7 @@ const statusLabel: Record<SubscriptionStatus, { label: string; className: string
 }
 
 export function SubscriptionsPage() {
-  const { data: subscriptions, isLoading } = useQuery<Subscription[]>({
+  const { data: subscriptions, isLoading, error } = useQuery<Subscription[]>({
     queryKey: ['subscriptions'],
     queryFn: () => api.get('/subscriptions').then((r) => r.data),
   })
@@ -42,6 +42,14 @@ export function SubscriptionsPage() {
             </tbody>
           </table>
         </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Falha ao carregar assinaturas. Tente novamente.
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Dashboard, Organizations, Invoices, Subscriptions pages now show a red error banner when the API call fails
- Replaces infinite skeleton / silent empty state on network/server errors

Closes #7