### PR TITLE
fix: normalize validation error shape from ValidationPipe

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core'
-import { ValidationPipe } from '@nestjs/common'
+import { ValidationPipe, BadRequestException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import * as cookieParser from 'cookie-parser'
@@ -29,6 +29,14 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: true,
       transform: true,
+      exceptionFactory: (errors) =>
+        new BadRequestException({
+          message: 'Validation failed',
+          errors: errors.map((e) => ({
+            field: e.property,
+            messages: Object.values(e.constraints ?? {}),
+          })),
+        }),
     }),
   )
 


### PR DESCRIPTION
## Summary
Adds `exceptionFactory` to the global `ValidationPipe` so validation failures return a consistent structure:

```json
{
  "message": "Validation failed",
  "errors": [
    { "field": "email", "messages": ["email must be an email"] }
  ]
}
```

Instead of the raw `class-validator` output that exposed internal field names and nested constraint objects.

Closes #13