### PR TITLE
docs: update CLAUDE.md to reflect current project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Pelvi Admin is a full-stack SaaS admin dashboard for managing clinic organizatio
 
 **Package manager**: **Bun** (`bun.lock` is the lockfile of record in both `backend/` and `frontend/`). Do not commit `package-lock.json`.
 
-See the parent `C:/Repos/Pelvi/CLAUDE.md` for how this project talks to `pelvi-ui` (shared `INTERNAL_API_KEY`, no cross-DB FKs — integration is HTTP-only via the `clinic-api/` module).
+See the parent `CLAUDE.md` for how this project talks to `pelvi-ui` (shared `INTERNAL_API_KEY`, no cross-DB FKs — integration is HTTP-only via the `clinic-api/` module).
 
 ---
 
@@ -92,12 +92,16 @@ bun run prisma:studio          # Open Prisma Studio UI
 ### Environment Setup
 
 Copy `backend/.env.example` to `backend/.env.dev` and populate:
-- `DATABASE_ADMIN_URL` — PostgreSQL connection string
-- `JWT_ADMIN_SECRET` — JWT signing secret
-- `PORT` — Backend port (default 3001)
-- `CORS_ORIGIN` — Frontend URL for CORS (required in production)
-- `CLINIC_API_URL` — Base URL of the pelvi-ui clinic API (e.g. `http://localhost:3000`). The admin appends `/api/internal/*` — do **not** include the path prefix in this value.
-- `CLINIC_INTERNAL_API_KEY` — Shared secret for clinic API requests. Must match `INTERNAL_API_KEY` on the clinic side.
+
+| Variable | Purpose |
+|----------|---------|
+| `DATABASE_ADMIN_URL` | PostgreSQL connection string |
+| `JWT_ADMIN_SECRET` | JWT signing secret (access token) |
+| `JWT_ADMIN_REFRESH_SECRET` | JWT signing secret (refresh token — must differ from access) |
+| `PORT` | Backend port (default 3001) |
+| `CORS_ORIGIN` | Frontend URL for CORS (required in production) |
+| `CLINIC_API_URL` | Base URL of the pelvi-ui clinic API (e.g. `http://localhost:3000`). Admin appends `/api/internal/*` — do **not** include the path prefix. |
+| `CLINIC_INTERNAL_API_KEY` | Shared secret for clinic API requests (`x-internal-api-key` header). Must match `INTERNAL_API_KEY` on the clinic side. Rotation policy: every 90 days or immediately on suspected compromise. |
 
 ### Docker
 
@@ -110,12 +114,13 @@ Both frontend and backend have a `Dockerfile`. The backend uses `docker-entrypoi
 ### Frontend (`frontend/src/`)
 
 React SPA (React Router DOM 7) with:
-- **Server state**: TanStack React Query — all API calls use query hooks with caching/refetch
-- **Auth state**: `contexts/AdminAuthContext.tsx` — stores user in React state, session validated via `GET /auth/me` on mount; provides `useAdminAuth()`
-- **HTTP client**: `lib/api.ts` — Axios instance with `withCredentials: true` (sends httpOnly `admin_token` cookie automatically) and redirects to `/login` on 401. No token stored in JS.
-- **Toast**: `contexts/ToastContext.tsx` — `useToast()` with `toast.success/error`; use `getErrorMessage(err)` from `lib/utils.ts` to extract server messages
-- **Forms**: React Hook Form + Zod validation (including `superRefine` for conditional validation in multi-mode forms)
-- **Styling**: Tailwind CSS with CSS variable-based theming; `ui/` primitives are Radix UI wrappers
+- **Server state**: TanStack React Query — all API calls use query hooks with caching/refetch. List endpoints (`/invoices`, `/subscriptions`) return `{ data: T[], total: number, page: number, limit: number }` — destructure `data` before rendering.
+- **Auth state**: `contexts/AdminAuthContext.tsx` — stores user in React state, session validated via `GET /auth/me` on mount; provides `useAdminAuth()`. Auth uses httpOnly cookies (`admin_token` + `admin_refresh_token`); no token stored in JS.
+- **HTTP client**: `lib/api.ts` — Axios instance with `withCredentials: true` (sends cookies automatically). Interceptor handles 401 → automatic refresh via `POST /auth/refresh` → retry once; on refresh failure redirects to `/login`.
+- **Toast**: `contexts/ToastContext.tsx` — `useToast()` with `toast.success/error`; use `getErrorMessage(err)` from `lib/utils.ts` to extract server messages.
+- **Forms**: React Hook Form + Zod validation (including `superRefine` for conditional validation in multi-mode forms).
+- **Styling**: Tailwind CSS with CSS variable-based theming; `ui/` primitives are Radix UI wrappers.
+- **Error states**: all list pages (`Dashboard`, `Organizations`, `Invoices`, `Subscriptions`) show a red error banner when the query fails — never an infinite skeleton.
 
 **Routing**: Protected by `components/auth/ProtectedRoute.tsx`. Layout routes under `/` render `AdminLayout` → `AdminSidebar` + `AdminTopBar` with nested pages (Dashboard, Organizations, OrganizationDetail, Plans, Subscriptions, Invoices).
 
@@ -125,57 +130,73 @@ React SPA (React Router DOM 7) with:
 
 **Formatters** (`lib/utils.ts`): `formatCurrency`, `formatDate`, `formatCNPJ`, `formatCPF`, `getErrorMessage`, `cn` (tailwind-merge).
 
+**Frontend types** (`src/types/admin.ts`): `AdminUser`, `Organization`, `Plan`, `Subscription`, `Invoice`, `MetricsSummary`, `PaginatedResponse<T>`. `PaginatedResponse<T>` is `{ data: T[], total: number }` — used by Organizations. Invoices/Subscriptions return an extended shape `{ data, total, page, limit }`.
+
 ### Backend (`backend/src/`)
 
 NestJS 11 API on port 3001. Global prefix `/api/admin`. Swagger docs at `/api/admin/docs`.
 
 **Top-level middleware** (in `main.ts`):
 - `helmet()` — security headers
-- `cookie-parser` — required to read the `admin_token` httpOnly cookie
-- `ValidationPipe` global (whitelist + transform)
-- CORS with `credentials: true` (to accept the cookie); `CORS_ORIGIN` must be set to a production domain in prod or startup fails
+- `cookie-parser` — required to read httpOnly auth cookies
+- `ValidationPipe` global (whitelist + forbidNonWhitelisted + transform). `exceptionFactory` normalizes validation errors to `{ message: 'Validation failed', errors: [{ field, messages }] }` — do NOT change this shape; frontend `getErrorMessage` depends on it.
+- `GlobalExceptionFilter` — standardizes all unhandled errors to `{ statusCode, message, timestamp }`.
+- CORS with `credentials: true`; `CORS_ORIGIN` must be a non-localhost domain in production or startup fails.
+
+**Rate limiting**: `AdminThrottlerGuard` extends `ThrottlerGuard` — tracks by `admin:<userId>` for authenticated requests, `ip:<ip>` for anonymous. Applied globally (100 req/min default). Stricter per-route `@Throttle()` on sensitive endpoints (password reset: 5/min).
+
+**Auth**: JWT via Passport (`auth/strategies/jwt.strategy.ts`) reading the `admin_token` httpOnly cookie. Refresh token rotation via `POST /auth/refresh` (reads `admin_refresh_token` cookie, issues new pair, rotates DB entry). Guards:
+- `JwtAuthGuard` — verifies access token (applied per-controller via `@UseGuards`)
+- `RolesGuard` — checks `@Roles()` decorator against `AdminRole` enum
+
+Login issues both cookies server-side; logout clears them and revokes the refresh token in DB (`AdminRefreshToken` model).
+
+**Admin roles**: `SUPER_ADMIN`, `FINANCE`, `SUPPORT` — defined in Prisma schema and `types/admin.ts`.
 
 **Module layout** — each feature follows a layered pattern:
 - `dto/` — request/response shapes (class-validator decorators)
 - `domain/` — entities and repository interfaces
 - `application/` — use cases (single-responsibility classes)
-- `infra/` — Prisma repository implementations and external service clients
+- `infra/` — Prisma repository implementations
 
-**Rate limiting**: `@nestjs/throttler` applied globally in `AppModule` with a default of 100 req/min. Endpoints that do auth-heavy work (password reset, login) are candidates for a stricter per-route `@Throttle()` — see the open tracking issues (e.g. reset-password rate limit).
+**External integration (`clinic-api/`)**: `ClinicApiService` is the single seam for HTTP calls to pelvi-ui using `CLINIC_INTERNAL_API_KEY` as `x-internal-api-key`. It:
+- Appends `/api/internal/*` to `CLINIC_API_URL` — do **not** include that path in the env var.
+- Uses a `buildUrl` tagged-template helper that `encodeURIComponent`-s every dynamic segment and asserts `URL.origin` matches the configured base — blocks SSRF/path-traversal.
+- Supported operations: clinic create/list, access update, person upsert, link person to clinic (ADMIN/PROFESSIONAL/RECEPTIONIST), list/update/reset-password clinic users.
 
-**Auth**: JWT via Passport (`auth/strategies/jwt.strategy.ts`) reading the token from the httpOnly cookie `admin_token`. Guards:
-- `JwtAuthGuard` — verifies token (applied per-controller via `@UseGuards`)
-- `RolesGuard` — checks `@Roles()` decorator against `AdminRole` enum
-
-Login issues the cookie server-side; logout clears it.
-
-**Admin roles**: `SUPER_ADMIN`, `FINANCE`, `SUPPORT` — defined in Prisma schema and `types/admin.ts`.
-
-**External integration (`clinic-api/`)**: the `ClinicApiService` is the single seam that talks to the pelvi-ui clinic backend over HTTP using the shared `CLINIC_INTERNAL_API_KEY` header. It:
-- Appends `/api/internal/*` to `CLINIC_API_URL` — the clinic product sets a `/api` global prefix, so do **not** call `/internal/*` directly.
-- Builds outbound URLs via a `buildUrl` tagged-template helper that `encodeURIComponent`-s every dynamic segment and asserts the final `URL.origin` matches the configured base — this blocks SSRF / path-traversal when ids come from HTTP params.
-- Supported operations: clinic create/list, access update, **person upsert**, **link person to clinic (ADMIN/PROFESSIONAL/RECEPTIONIST)**, **list/update/reset-password clinic users**.
-
-**Organizations module**: houses the bulk of the cross-system orchestration. Use cases in `organizations/application/`:
-- `create-organization.usecase.ts` — legacy flow that links an existing clinic by `clinicExternalId`
-- `create-organization-with-owner.usecase.ts` — the standard flow (see sequence diagram in parent repo `docs/sequence.mermaid`): creates Clinic → upserts Person responsável by CPF → links as ADMIN → persists Organization locally. Idempotent: reusing CPF returns the existing Person with `provisionalPassword: null`.
-- `provisional-password.ts` — generates provisional passwords with `crypto.randomInt` (rejection sampling — do NOT use `randomBytes % alphabet.length`, that's biased).
-- `reset-clinic-user-password.usecase.ts` — generates a new provisional password and invalidates the previous one via the clinic-api.
-- `resolve-clinic-id.ts` — helper that converts admin `organizationId` → `clinicExternalId` before any clinic-api call (since the two DBs share only that link).
+**Organizations module** (`organizations/application/`):
+- `create-organization-with-owner.usecase.ts` — **standard org creation flow**: creates Clinic in pelvi-ui → upserts Person by CPF → links as ADMIN → persists Organization locally → creates TRIAL Subscription (+14 days) → propagates plan limits to pelvi-ui. Returns `{ organization, owner, subscription, provisionalPassword }`. Reusing an existing CPF returns `provisionalPassword: null` and `owner.reused: true`.
+- `resolve-trial-plan.ts` — injectable helper that resolves the trial plan ID. Checks `TRIAL_PLAN_ID` env var first; falls back to DB lookup (`Plan.name ILIKE '%trial%', isActive = true`). Throws if neither exists.
+- `create-organization.usecase.ts` — legacy flow that links an existing clinic by `clinicExternalId` without creating a new one.
+- `provisional-password.ts` — generates passwords using `crypto.randomInt` (rejection sampling). Do NOT use `randomBytes % alphabet.length` — that's biased.
+- `reset-clinic-user-password.usecase.ts` — generates a new provisional password and pushes it to pelvi-ui via clinic-api.
+- `resolve-clinic-id.ts` — converts admin `organizationId` → `clinicExternalId` before any clinic-api call.
 - `list-organizations.usecase.ts`, `update-status.usecase.ts` — listing + status transitions.
+
+**`common/`**:
+- `filters/global-exception.filter.ts` — catches all unhandled exceptions, returns `{ statusCode, message, timestamp }`.
+- `guards/admin-throttler.guard.ts` — rate limiting by user ID or IP.
 
 ### Database (Prisma + PostgreSQL)
 
 Schema at `backend/prisma/schema.prisma`. Core models (all IDs are UUIDs):
-- `AdminUser` — internal admin accounts with `role`
-- `Organization` — SaaS customers. Linked to the clinic product via `clinicExternalId`. Status: `ACTIVE | SUSPENDED | CANCELED`
-- `Plan` — subscription tiers with pricing and feature flags
-- `Subscription` — links Organization → Plan (status: `TRIAL | ACTIVE | PAST_DUE | CANCELED`)
-- `Invoice` — billing records per subscription
 
-The admin DB knows nothing about Persons, OrganizationUsers, Patients, or Appointments — those live in the clinic product and are reached only via `clinic-api/`.
+| Model | Key fields | Notes |
+|-------|-----------|-------|
+| `AdminUser` | `role: AdminRole` | Internal admin accounts |
+| `AdminRefreshToken` | `tokenHash`, `expiresAt`, `revokedAt` | Refresh token rotation; `onDelete: Cascade` from AdminUser |
+| `Organization` | `document: String @unique`, `clinicExternalId`, `status: OrgStatus` | SaaS customers. Linked to clinic product via `clinicExternalId` (no cross-DB FK). |
+| `Plan` | `priceMonthly`, `maxUsers`, `maxPatients`, `features: Json?` | Subscription tiers |
+| `Subscription` | `status: SubscriptionStatus`, `trialEndsAt` | `onDelete: Cascade` from Organization; `onDelete: Restrict` from Plan; `@@unique([organizationId, planId])` — one active plan per org. |
+| `Invoice` | `amount`, `status: InvoiceStatus`, `dueDate` | `onDelete: Cascade` from Subscription |
 
-After any schema change run `bun run prisma:generate` to update the Prisma client, then `bun run prisma:migrate:dev` to create and apply a migration.
+Cascade rules:
+- Deleting an `Organization` → cascades to its `Subscription`s → cascades to their `Invoice`s.
+- Deleting a `Plan` is blocked if any `Subscription` references it (`Restrict`).
+
+After any schema change: `bun run prisma:generate` then `bun run prisma:migrate:dev`.
+
+**Paginated list endpoints** (`GET /invoices`, `GET /subscriptions`) accept `page` (default 1) and `limit` (default 50, max 100) query params and return `{ data, total, page, limit }`.
 
 ### Path Aliases
 


### PR DESCRIPTION
Atualiza o CLAUDE.md com o estado real do repositório após os merges recentes.

## O que mudou

- **Auth**: documenta rotação de refresh token + cookies httpOnly para os dois tokens; `JWT_ADMIN_REFRESH_SECRET`
- **ValidationPipe**: documenta o shape normalizado `{ message, errors[{field,messages}] }` e avisa para não alterar (frontend depende)
- **GlobalExceptionFilter**: documenta `{ statusCode, message, timestamp }`
- **AdminThrottlerGuard**: documenta rastreamento por `userId` vs `IP`
- **Organizations**: documenta fluxo completo do `create-with-owner` (subscription TRIAL + propagação de limites); `resolve-trial-plan.ts`
- **Database**: tabela de cascade/restrict, `@@unique([organizationId, planId])`
- **List endpoints**: documenta shape `{ data, total, page, limit }` e limite máximo de 100 linhas
- **Frontend**: documenta error states, destructuring de resposta paginada, tipo `PaginatedResponse<T>`
- **Env vars**: adiciona `JWT_ADMIN_REFRESH_SECRET`, documenta política de rotação do `CLINIC_INTERNAL_API_KEY`