### PR TITLE
fix: handle network errors in Axios interceptor and getErrorMessage

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -57,6 +57,12 @@ api.interceptors.response.use(
       window.location.href = '/login'
     }
 
+    if (!error.response) {
+      const friendly = new Error('Sem conexão com o servidor. Verifique sua rede e tente novamente.')
+      ;(friendly as Error & { isNetworkError?: boolean }).isNetworkError = true
+      return Promise.reject(friendly)
+    }
+
     return Promise.reject(error)
   },
 )

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -22,6 +22,9 @@ export function formatCPF(cpf: string) {
 }
 
 export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && (error as Error & { isNetworkError?: boolean }).isNetworkError) {
+    return error.message
+  }
   if (error && typeof error === 'object' && 'response' in error) {
     const response = (error as { response?: { data?: { message?: unknown } } }).response
     const msg = response?.data?.message


### PR DESCRIPTION
## Summary
- Detect `!error.response` in Axios interceptor and reject with a user-friendly `Error` tagged as `isNetworkError`
- Update `getErrorMessage` to check `isNetworkError` first, returning the message directly instead of the generic fallback

## Test plan
- [ ] Simular rede desligada: toast deve exibir "Sem conexão com o servidor..."
- [ ] 401 + refresh flow continua funcionando
- [ ] `getErrorMessage` com erro normal de API retorna mensagem do servidor

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)