### PR TITLE
fix: adicionar plano Trial no seed do banco

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -11,6 +11,13 @@ async function main() {
   // Planos padrão
   const plans = [
     {
+      name: 'Trial',
+      priceMonthly: 0,
+      maxUsers: 3,
+      maxPatients: 50,
+      features: { nfse: false, whatsapp: false, reports: false, trial: true },
+    },
+    {
       name: 'Básico',
       priceMonthly: 97,
       maxUsers: 3,
@@ -41,7 +48,7 @@ async function main() {
     })
   }
 
-  console.log(`✅ ${plans.length} planos criados`)
+  console.log(`✅ ${plans.length} planos criados (inclui Trial)`)
 
   // Super admin inicial
   const adminEmail = process.env.SEED_ADMIN_EMAIL ?? 'admin@soupelvi.com.br'


### PR DESCRIPTION
## Summary

- Adiciona plano Trial (preço R$0, 3 usuários, 50 pacientes, 14 dias) no seed idempotente
- Sem o plano Trial, `ResolveTrialPlan` lança exceção em ambiente recém-seedado, quebrando completamente o fluxo de criação de organização

## Test plan

- [ ] `bun run prisma:seed` em banco limpo → plano Trial criado
- [ ] Re-executar seed → sem erro (idempotente via `upsert`)
- [ ] Criar nova organização → subscription Trial criada corretamente

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)