### PR TITLE
fix(security): gate Swagger em produção, headers nginx, health check real

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -50,11 +50,16 @@ async function bootstrap() {
     .build()
 
   const document = SwaggerModule.createDocument(app, swaggerConfig)
-  SwaggerModule.setup('api/admin/docs', app, document)
+
+  if (process.env.NODE_ENV !== 'production') {
+    SwaggerModule.setup('api/admin/docs', app, document)
+  }
 
   await app.listen(port)
   console.log(`🚀 Admin API running on http://localhost:${port}/api/admin`)
-  console.log(`📖 Swagger docs: http://localhost:${port}/api/admin/docs`)
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(`📖 Swagger docs: http://localhost:${port}/api/admin/docs`)
+  }
 }
 
 bootstrap()

--- a/backend/src/version/version.controller.ts
+++ b/backend/src/version/version.controller.ts
@@ -1,11 +1,19 @@
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, ServiceUnavailableException } from '@nestjs/common'
 import { ApiTags } from '@nestjs/swagger'
+import { PrismaService } from '../prisma/prisma.service'
 
 @ApiTags('health')
 @Controller('health')
 export class VersionController {
+  constructor(private readonly prisma: PrismaService) {}
+
   @Get()
-  get() {
+  async get() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`
+    } catch {
+      throw new ServiceUnavailableException('Database unavailable')
+    }
     return { status: 'ok', message: 'Tudo estável' }
   }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

**S-1** — Swagger (`/api/admin/docs`) agora só é montado quando `NODE_ENV !== 'production'`. Em produção, a rota não existe — nenhum mapa de endpoints, DTOs ou schemas exposto publicamente.

**S-3** — nginx do frontend agora envia 5 security headers em todas as respostas:
- `X-Frame-Options: DENY` — bloqueia clickjacking
- `X-Content-Type-Options: nosniff` — bloqueia MIME sniffing
- `Strict-Transport-Security` — força HTTPS por 2 anos
- `Content-Security-Policy` — restringe fontes de scripts, estilos e conexões
- `Referrer-Policy` — limita vazamento de URL em navegação cross-origin

**S-6** — `GET /api/admin/health` agora executa `SELECT 1` antes de responder 200. Falha de conexão com o banco retorna 503 — Railway para de rotear tráfego para o container.

## Test plan

- [ ] Em dev: `/api/admin/docs` acessível
- [ ] Em prod (`NODE_ENV=production`): `/api/admin/docs` retorna 404
- [ ] Health check com DB up → `{ status: 'ok' }`
- [ ] Health check com DB down → 503
- [ ] Headers de segurança presentes nas respostas do nginx (verificar via DevTools → Network)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)