### PR TITLE
fix(security): ParseUUIDPipe em todos os @Param('id') dos controllers

### DIFF
--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common'
+import { Controller, Get, Post, Patch, Body, Param, ParseUUIDPipe, Query, UseGuards } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -47,19 +47,19 @@ export class InvoicesController {
 
   @Get(':id')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.invoicesService.findOne(id)
   }
 
   @Patch(':id/mark-paid')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  markPaid(@Param('id') id: string) {
+  markPaid(@Param('id', ParseUUIDPipe) id: string) {
     return this.invoicesService.markPaid(id)
   }
 
   @Patch(':id/cancel')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  cancel(@Param('id') id: string) {
+  cancel(@Param('id', ParseUUIDPipe) id: string) {
     return this.invoicesService.cancel(id)
   }
 }

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -1,6 +1,6 @@
 import {
   Controller, Get, Post, Patch, Delete,
-  Body, Param, Query, UseGuards,
+  Body, Param, ParseUUIDPipe, Query, UseGuards,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger'
 import { Throttle } from '@nestjs/throttler'
@@ -74,25 +74,25 @@ export class OrganizationsController {
 
   @Get(':id')
   @Roles('SUPER_ADMIN', 'SUPPORT')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.repo.findById(id)
   }
 
   @Patch(':id')
   @Roles('SUPER_ADMIN', 'SUPPORT')
-  update(@Param('id') id: string, @Body() dto: UpdateOrganizationDto) {
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateOrganizationDto) {
     return this.repo.update(id, dto)
   }
 
   @Patch(':id/status')
   @Roles('SUPER_ADMIN', 'SUPPORT')
-  updateStatus(@Param('id') id: string, @Body() dto: UpdateOrgStatusDto) {
+  updateStatus(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateOrgStatusDto) {
     return this.updateOrgStatus.execute(id, dto.status)
   }
 
   @Delete(':id')
   @Roles('SUPER_ADMIN')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ParseUUIDPipe) id: string) {
     return this.repo.delete(id)
   }
 
@@ -100,7 +100,7 @@ export class OrganizationsController {
 
   @Get(':id/users')
   @Roles('SUPER_ADMIN', 'SUPPORT')
-  async listClinicUsers(@Param('id') id: string) {
+  async listClinicUsers(@Param('id', ParseUUIDPipe) id: string) {
     const clinicId = await this.resolveClinicId.byOrganizationId(id)
     return this.clinicApi.listClinicUsers(clinicId)
   }
@@ -108,8 +108,8 @@ export class OrganizationsController {
   @Patch(':id/users/:organizationUserId')
   @Roles('SUPER_ADMIN', 'SUPPORT')
   async updateClinicUser(
-    @Param('id') id: string,
-    @Param('organizationUserId') organizationUserId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('organizationUserId', ParseUUIDPipe) organizationUserId: string,
     @Body() dto: UpdateClinicUserDto,
   ) {
     const clinicId = await this.resolveClinicId.byOrganizationId(id)
@@ -121,8 +121,8 @@ export class OrganizationsController {
   @UseGuards(AdminThrottlerGuard)
   @Throttle({ default: { limit: 5, ttl: 600_000 } })
   resetUserPassword(
-    @Param('id') id: string,
-    @Param('organizationUserId') organizationUserId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('organizationUserId', ParseUUIDPipe) organizationUserId: string,
   ) {
     return this.resetClinicUserPassword.execute(id, organizationUserId)
   }

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Delete, Body, Param, UseGuards } from '@nestjs/common'
+import { Controller, Get, Post, Patch, Delete, Body, Param, ParseUUIDPipe, UseGuards } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -26,19 +26,19 @@ export class PlansController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.plansService.findOne(id)
   }
 
   @Patch(':id')
   @Roles('SUPER_ADMIN')
-  update(@Param('id') id: string, @Body() dto: UpdatePlanDto) {
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdatePlanDto) {
     return this.plansService.update(id, dto)
   }
 
   @Delete(':id')
   @Roles('SUPER_ADMIN')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ParseUUIDPipe) id: string) {
     return this.plansService.remove(id)
   }
 }

--- a/backend/src/subscriptions/subscriptions.controller.ts
+++ b/backend/src/subscriptions/subscriptions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common'
+import { Controller, Get, Post, Patch, Body, Param, ParseUUIDPipe, Query, UseGuards } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -41,19 +41,19 @@ export class SubscriptionsController {
 
   @Get(':id')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.subscriptionsService.findOne(id)
   }
 
   @Patch(':id')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  update(@Param('id') id: string, @Body() dto: Partial<CreateSubscriptionDto>) {
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: Partial<CreateSubscriptionDto>) {
     return this.subscriptionsService.update(id, dto)
   }
 
   @Patch(':id/cancel')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  cancel(@Param('id') id: string) {
+  cancel(@Param('id', ParseUUIDPipe) id: string) {
     return this.subscriptionsService.cancel(id)
   }
 }


### PR DESCRIPTION
## Summary

Todos os `@Param('id')` e `@Param('organizationUserId')` nos controllers agora usam `ParseUUIDPipe`. Input não-UUID (path traversal, SQL fragments, strings aleatórias) retorna 400 antes de chegar ao Prisma — eliminando round-trips desnecessários ao DB e o vazamento de detalhes internos via 500.

Controllers cobertos:
- `organizations` — `:id` e `:organizationUserId`
- `plans` — `:id`
- `subscriptions` — `:id`
- `invoices` — `:id`

## Test plan

- [ ] `GET /organizations/not-a-uuid` → 400 (não 500)
- [ ] `GET /plans/abc` → 400
- [ ] `GET /invoices/123` → 400
- [ ] `GET /organizations/:valid-uuid` → resposta normal

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)