### PR TITLE
fix: compensating transaction no fluxo de criação de organização

### DIFF
--- a/backend/src/organizations/application/create-organization-with-owner.usecase.spec.ts
+++ b/backend/src/organizations/application/create-organization-with-owner.usecase.spec.ts
@@ -23,10 +23,13 @@ const makeOrg = (overrides: Partial<Organization> = {}): Organization => ({
   ...overrides,
 })
 
-const makeSub = () => ({
+const makeSub = (orgId = 'org-1') => ({
   id: 'sub-1',
+  organizationId: orgId,
+  planId: 'plan-trial-id',
   status: 'TRIAL',
   trialEndsAt: new Date(Date.now() + 14 * 86400000),
+  startDate: new Date(),
 })
 
 const baseInput: CreateOrganizationWithOwnerInput = {
@@ -50,17 +53,30 @@ const personResp = (reused = false) => ({
     cpf: '12345678900',
     name: 'Ana Lima',
     email: 'ana@test.com',
+    phone: null,
+    active: true,
+  },
+})
+
+const makeTx = (orgOverride: Partial<Organization> = {}) => ({
+  organization: {
+    create: jest.fn().mockResolvedValue(makeOrg(orgOverride)),
+  },
+  subscription: {
+    create: jest.fn().mockResolvedValue(makeSub(orgOverride.id ?? 'org-1')),
   },
 })
 
 describe('CreateOrganizationWithOwnerUseCase', () => {
   let repo: jest.Mocked<IOrganizationRepository>
   let clinicApi: jest.Mocked<ClinicApiService>
-  let prisma: jest.Mocked<Pick<PrismaService, 'subscription' | 'plan'>>
+  let prisma: jest.Mocked<Pick<PrismaService, '$transaction' | 'plan'>>
   let resolveTrialPlan: jest.Mocked<ResolveTrialPlan>
   let sut: CreateOrganizationWithOwnerUseCase
+  let tx: ReturnType<typeof makeTx>
 
   beforeEach(() => {
+    tx = makeTx()
     repo = {
       findById: jest.fn(),
       findAll: jest.fn(),
@@ -71,15 +87,15 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
     clinicApi = {
       createClinic: jest.fn(),
       listClinics: jest.fn(),
-      updateClinicAccess: jest.fn(),
+      updateClinicAccess: jest.fn().mockResolvedValue(undefined),
       upsertPerson: jest.fn(),
-      linkPersonToClinic: jest.fn(),
+      linkPersonToClinic: jest.fn().mockResolvedValue(undefined),
       listClinicUsers: jest.fn(),
       updateClinicUser: jest.fn(),
       resetClinicUserPassword: jest.fn(),
     } as any
     prisma = {
-      subscription: { create: jest.fn().mockResolvedValue(makeSub()) } as any,
+      $transaction: jest.fn().mockImplementation(async (fn: (tx: any) => Promise<unknown>) => fn(tx)),
       plan: { findUniqueOrThrow: jest.fn().mockResolvedValue({ maxUsers: 5, maxPatients: 100 }) } as any,
     }
     resolveTrialPlan = { planId: jest.fn().mockResolvedValue('plan-trial-id') } as any
@@ -101,28 +117,29 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
     repo.findAll.mockResolvedValue({ data: [], total: 0 })
     clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
     clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
-    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
-    repo.create.mockResolvedValue(makeOrg({ clinicExternalId: 'clinic-new' }))
 
     await sut.execute(baseInput)
 
     expect(clinicApi.createClinic).toHaveBeenCalled()
     expect(clinicApi.upsertPerson).toHaveBeenCalled()
     expect(clinicApi.linkPersonToClinic).toHaveBeenCalled()
-    expect(repo.create).toHaveBeenCalled()
-    expect(prisma.subscription.create).toHaveBeenCalled()
+    expect(prisma.$transaction).toHaveBeenCalled()
+    expect(tx.organization.create).toHaveBeenCalled()
+    expect(tx.subscription.create).toHaveBeenCalled()
+    expect(clinicApi.updateClinicAccess).toHaveBeenCalled()
   })
 
-  it('creates TRIAL subscription with 14-day trialEndsAt', async () => {
+  it('creates TRIAL subscription with 14-day trialEndsAt inside the transaction', async () => {
+    tx = makeTx({ id: 'org-new' })
+    prisma.$transaction.mockImplementation(async (fn: (tx: any) => Promise<unknown>) => fn(tx))
+
     repo.findAll.mockResolvedValue({ data: [], total: 0 })
     clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
     clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
-    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
-    repo.create.mockResolvedValue(makeOrg({ id: 'org-new' }))
 
     await sut.execute(baseInput)
 
-    expect(prisma.subscription.create).toHaveBeenCalledWith(
+    expect(tx.subscription.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           organizationId: 'org-new',
@@ -137,20 +154,17 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
     repo.findAll.mockResolvedValue({ data: [], total: 0 })
     clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
     clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
-    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
-    repo.create.mockResolvedValue(makeOrg())
 
     const result = await sut.execute(baseInput)
 
     expect(result.subscription).toMatchObject({ id: 'sub-1', status: 'TRIAL' })
+    expect(result.subscription.trialEndsAt).toBeInstanceOf(Date)
   })
 
   it('returns provisionalPassword when person is newly created', async () => {
     repo.findAll.mockResolvedValue({ data: [], total: 0 })
     clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
     clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
-    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
-    repo.create.mockResolvedValue(makeOrg())
 
     const result = await sut.execute(baseInput)
 
@@ -162,8 +176,6 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
     repo.findAll.mockResolvedValue({ data: [], total: 0 })
     clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
     clinicApi.upsertPerson.mockResolvedValue(personResp(true) as any)
-    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
-    repo.create.mockResolvedValue(makeOrg())
 
     const result = await sut.execute(baseInput)
 
@@ -175,8 +187,6 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
     repo.findAll.mockResolvedValue({ data: [], total: 0 })
     clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-new' } as any)
     clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
-    clinicApi.linkPersonToClinic.mockResolvedValue(undefined as any)
-    repo.create.mockResolvedValue(makeOrg())
 
     await sut.execute(baseInput)
 
@@ -184,5 +194,16 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
       'clinic-new',
       expect.objectContaining({ personId: 'person-1', role: 'ADMIN' }),
     )
+  })
+
+  it('blocks clinic in pelvi-ui and rethrows when local persistence fails', async () => {
+    repo.findAll.mockResolvedValue({ data: [], total: 0 })
+    clinicApi.createClinic.mockResolvedValue({ clinicId: 'clinic-fail' } as any)
+    clinicApi.upsertPerson.mockResolvedValue(personResp(false) as any)
+    const dbError = new Error('DB connection lost')
+    prisma.$transaction.mockRejectedValue(dbError)
+
+    await expect(sut.execute(baseInput)).rejects.toThrow('DB connection lost')
+    expect(clinicApi.updateClinicAccess).toHaveBeenCalledWith('clinic-fail', 'BLOCKED')
   })
 })

--- a/backend/src/organizations/application/create-organization-with-owner.usecase.ts
+++ b/backend/src/organizations/application/create-organization-with-owner.usecase.ts
@@ -67,6 +67,7 @@ export class CreateOrganizationWithOwnerUseCase {
       )
     }
 
+    // ── External calls (pelvi-ui) ────────────────────────────────────────────
     const clinic = await this.clinicApi.createClinic({
       name: input.name,
       document,
@@ -89,29 +90,60 @@ export class CreateOrganizationWithOwnerUseCase {
       role: 'ADMIN',
     })
 
-    const organization = await this.repo.create({
-      name: input.name,
-      document,
-      documentType,
-      email: input.email,
-      phone: input.phone ?? null,
-      status: 'ACTIVE',
-      clinicExternalId: clinic.clinicId,
-    })
-
+    // ── Local persistence (atomic) ───────────────────────────────────────────
+    // If this fails, the clinic already exists in pelvi-ui. Compensate by
+    // blocking it so it cannot be used until an operator resolves the conflict.
     const trialPlanId = await this.resolveTrialPlan.planId()
     const trialEndsAt = new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000)
 
-    const subscription = await this.prisma.subscription.create({
-      data: {
-        organizationId: organization.id,
-        planId: trialPlanId,
-        status: 'TRIAL',
-        startDate: new Date(),
-        trialEndsAt,
-      },
-    })
+    let organization: Organization
+    let subscription: { id: string; status: string; trialEndsAt: Date }
 
+    try {
+      const result = await this.prisma.$transaction(async (tx) => {
+        const org = await tx.organization.create({
+          data: {
+            name: input.name,
+            document,
+            documentType,
+            email: input.email,
+            phone: input.phone ?? null,
+            status: 'ACTIVE',
+            clinicExternalId: clinic.clinicId,
+          },
+        })
+        const sub = await tx.subscription.create({
+          data: {
+            organizationId: org.id,
+            planId: trialPlanId,
+            status: 'TRIAL',
+            startDate: new Date(),
+            trialEndsAt,
+          },
+        })
+        return { org, sub }
+      })
+      organization = result.org as Organization
+      subscription = {
+        id: result.sub.id,
+        status: result.sub.status,
+        trialEndsAt: result.sub.trialEndsAt!,
+      }
+    } catch (persistenceError) {
+      this.logger.error(
+        `Local persistence failed for clinic ${clinic.clinicId} — blocking in pelvi-ui as compensation`,
+      )
+      try {
+        await this.clinicApi.updateClinicAccess(clinic.clinicId, 'BLOCKED')
+      } catch {
+        this.logger.error(
+          `Compensation also failed for clinic ${clinic.clinicId} — manual cleanup required`,
+        )
+      }
+      throw persistenceError
+    }
+
+    // ── Propagate plan limits to pelvi-ui ────────────────────────────────────
     const plan = await this.prisma.plan.findUniqueOrThrow({ where: { id: trialPlanId } })
     await this.clinicApi.updateClinicAccess(clinic.clinicId, 'ACTIVE', {
       maxUsers: plan.maxUsers,
@@ -119,7 +151,7 @@ export class CreateOrganizationWithOwnerUseCase {
     })
 
     if (personResp.reused) {
-      this.logger.log(`Owner reaproveitado (cpf=${input.owner.cpf}); senha provisória não foi redefinida.`)
+      this.logger.log(`Owner reaproveitado (cpf=***${input.owner.cpf.slice(-3)}); senha provisória não foi redefinida.`)
     }
 
     return {
@@ -131,11 +163,7 @@ export class CreateOrganizationWithOwnerUseCase {
         email: personResp.person.email,
         reused: personResp.reused,
       },
-      subscription: {
-        id: subscription.id,
-        status: subscription.status,
-        trialEndsAt: subscription.trialEndsAt!,
-      },
+      subscription,
       provisionalPassword: personResp.reused ? null : provisionalPassword,
     }
   }


### PR DESCRIPTION
## Summary

Steps 4+5 do fluxo de criação de org (persistência local: `organization` + `subscription`) agora executam numa única `$transaction` Prisma. Se qualquer um falhar:

1. O DB local faz rollback automaticamente (atomicidade garantida)
2. Uma chamada compensatória bloqueia a clínica no pelvi-ui (`updateClinicAccess → BLOCKED`) — evitando que um registro órfão fique operacional no produto
3. Se a compensação também falhar, o erro é logado com o `clinicId` para limpeza manual

Também corrige o CPF no log de owner reaproveitado (mascarado para `***XXX`).

## Diagrama do fluxo com compensação

```
createClinic() → upsertPerson() → linkPerson()
    ↓ OK
$transaction { org.create + subscription.create }
    ↓ FALHA
updateClinicAccess(BLOCKED) ← compensação
    ↓
re-throw erro original → 500 para o caller
```

## Test plan

- [ ] Criação normal de org → funciona sem mudança de comportamento
- [ ] Simular falha de DB após clinic criada (mock) → clínica bloqueada no pelvi-ui
- [ ] Log mostra `cpf=***XXX` para owners reaproveitados

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)