### PR TITLE
test: cobertura dos módulos clinic-api, GlobalExceptionFilter e AdminThrottlerGuard

### DIFF
--- a/backend/src/clinic-api/clinic-api.service.spec.ts
+++ b/backend/src/clinic-api/clinic-api.service.spec.ts
@@ -1,0 +1,51 @@
+import { ServiceUnavailableException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { ClinicApiService } from './clinic-api.service'
+
+const makeConfig = (clinicApiUrl: string) =>
+  ({ getOrThrow: (key: string) => (key === 'CLINIC_API_URL' ? clinicApiUrl : 'test-key') }) as ConfigService
+
+const buildUrl = (svc: ClinicApiService, template: TemplateStringsArray, ...segments: string[]) =>
+  (svc as any).buildUrl(template, ...segments)
+
+const tpl = (str: string): TemplateStringsArray =>
+  Object.assign([str], { raw: [str] }) as unknown as TemplateStringsArray
+
+describe('ClinicApiService', () => {
+  describe('buildUrl — SSRF guard', () => {
+    it('returns a valid URL when path is safe', () => {
+      const svc = new ClinicApiService(makeConfig('http://localhost:3000'))
+      const url = buildUrl(svc, tpl('/api/internal/clinics'))
+      expect(url).toBe('http://localhost:3000/api/internal/clinics')
+    })
+
+    it('URI-encodes dynamic path segments', () => {
+      const svc = new ClinicApiService(makeConfig('http://localhost:3000'))
+      const template = Object.assign(['/api/internal/clinics/', '/users'], { raw: ['/api/internal/clinics/', '/users'] }) as unknown as TemplateStringsArray
+      const url = buildUrl(svc, template, 'a b/c')
+      expect(url).toBe('http://localhost:3000/api/internal/clinics/a%20b%2Fc/users')
+    })
+
+    it('throws when a template path changes the URL origin (SSRF via credential injection)', () => {
+      // http://localhost:3000@evil.com/api resolves origin to evil.com
+      const svc = new ClinicApiService(makeConfig('http://localhost:3000'))
+      expect(() => buildUrl(svc, tpl('@evil.com/api'))).toThrow(ServiceUnavailableException)
+    })
+
+    it('strips trailing slash from base URL before appending path', () => {
+      const svc = new ClinicApiService(makeConfig('http://localhost:3000/'))
+      const url = buildUrl(svc, tpl('/api/internal/clinics'))
+      expect(url).toBe('http://localhost:3000/api/internal/clinics')
+    })
+
+    it('builds multi-segment URLs correctly', () => {
+      const svc = new ClinicApiService(makeConfig('http://localhost:3000'))
+      const template = Object.assign(
+        ['/api/internal/clinics/', '/users/', '/reset-password'],
+        { raw: ['/api/internal/clinics/', '/users/', '/reset-password'] },
+      ) as unknown as TemplateStringsArray
+      const url = buildUrl(svc, template, 'clinic-id', 'user-id')
+      expect(url).toBe('http://localhost:3000/api/internal/clinics/clinic-id/users/user-id/reset-password')
+    })
+  })
+})

--- a/backend/src/common/filters/global-exception.filter.spec.ts
+++ b/backend/src/common/filters/global-exception.filter.spec.ts
@@ -17,11 +17,9 @@ describe('GlobalExceptionFilter', () => {
   })
 
   it('returns the HTTP status and message from HttpException', () => {
-    const statusFn = jest.fn().mockReturnValue({ json: jest.fn() })
+    const statusFn = jest.fn()
     const jsonFn = jest.fn()
-    const host = {
-      switchToHttp: () => ({ getResponse: () => ({ status: statusFn.mockReturnValue({ json: jsonFn }) }) }),
-    }
+    const host = makeHost(statusFn, jsonFn)
 
     filter.catch(new HttpException('Not found', HttpStatus.NOT_FOUND), host as any)
 
@@ -32,11 +30,9 @@ describe('GlobalExceptionFilter', () => {
   })
 
   it('returns 500 and generic message for non-HTTP errors', () => {
-    const statusFn = jest.fn().mockReturnValue({ json: jest.fn() })
+    const statusFn = jest.fn()
     const jsonFn = jest.fn()
-    const host = {
-      switchToHttp: () => ({ getResponse: () => ({ status: statusFn.mockReturnValue({ json: jsonFn }) }) }),
-    }
+    const host = makeHost(statusFn, jsonFn)
 
     filter.catch(new Error('something broke'), host as any)
 
@@ -63,10 +59,9 @@ describe('GlobalExceptionFilter', () => {
   })
 
   it('handles non-Error thrown values (strings, objects)', () => {
-    const statusFn = jest.fn().mockReturnValue({ json: jest.fn() })
-    const host = {
-      switchToHttp: () => ({ getResponse: () => ({ status: statusFn.mockReturnValue({ json: jest.fn() }) }) }),
-    }
+    const statusFn = jest.fn()
+    const jsonFn = jest.fn()
+    const host = makeHost(statusFn, jsonFn)
 
     expect(() => filter.catch('some string error', host as any)).not.toThrow()
     expect(statusFn).toHaveBeenCalledWith(500)

--- a/backend/src/common/filters/global-exception.filter.spec.ts
+++ b/backend/src/common/filters/global-exception.filter.spec.ts
@@ -1,0 +1,74 @@
+import { HttpException, HttpStatus } from '@nestjs/common'
+import { GlobalExceptionFilter } from './global-exception.filter'
+
+const makeHost = (statusFn = jest.fn(), jsonFn = jest.fn()) => ({
+  switchToHttp: () => ({
+    getResponse: () => ({
+      status: statusFn.mockReturnValue({ json: jsonFn }),
+    }),
+  }),
+})
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter
+
+  beforeEach(() => {
+    filter = new GlobalExceptionFilter()
+  })
+
+  it('returns the HTTP status and message from HttpException', () => {
+    const statusFn = jest.fn().mockReturnValue({ json: jest.fn() })
+    const jsonFn = jest.fn()
+    const host = {
+      switchToHttp: () => ({ getResponse: () => ({ status: statusFn.mockReturnValue({ json: jsonFn }) }) }),
+    }
+
+    filter.catch(new HttpException('Not found', HttpStatus.NOT_FOUND), host as any)
+
+    expect(statusFn).toHaveBeenCalledWith(404)
+    expect(jsonFn).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 404, message: 'Not found' }),
+    )
+  })
+
+  it('returns 500 and generic message for non-HTTP errors', () => {
+    const statusFn = jest.fn().mockReturnValue({ json: jest.fn() })
+    const jsonFn = jest.fn()
+    const host = {
+      switchToHttp: () => ({ getResponse: () => ({ status: statusFn.mockReturnValue({ json: jsonFn }) }) }),
+    }
+
+    filter.catch(new Error('something broke'), host as any)
+
+    expect(statusFn).toHaveBeenCalledWith(500)
+    expect(jsonFn).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 500, message: 'Internal server error' }),
+    )
+  })
+
+  it('includes a timestamp in the response', () => {
+    const captured: any[] = []
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({
+          status: jest.fn().mockReturnValue({ json: (body: any) => captured.push(body) }),
+        }),
+      }),
+    }
+
+    filter.catch(new HttpException('Bad request', 400), host as any)
+
+    expect(captured[0]).toHaveProperty('timestamp')
+    expect(typeof captured[0].timestamp).toBe('string')
+  })
+
+  it('handles non-Error thrown values (strings, objects)', () => {
+    const statusFn = jest.fn().mockReturnValue({ json: jest.fn() })
+    const host = {
+      switchToHttp: () => ({ getResponse: () => ({ status: statusFn.mockReturnValue({ json: jest.fn() }) }) }),
+    }
+
+    expect(() => filter.catch('some string error', host as any)).not.toThrow()
+    expect(statusFn).toHaveBeenCalledWith(500)
+  })
+})

--- a/backend/src/common/guards/admin-throttler.guard.spec.ts
+++ b/backend/src/common/guards/admin-throttler.guard.spec.ts
@@ -1,0 +1,59 @@
+import { ThrottlerException } from '@nestjs/throttler'
+import { AdminThrottlerGuard } from './admin-throttler.guard'
+
+class TestableAdminThrottlerGuard extends AdminThrottlerGuard {
+  constructor() {
+    super({} as any, {} as any, {} as any)
+  }
+  async testGetTracker(req: Record<string, unknown>): Promise<string> {
+    return this.getTracker(req)
+  }
+  async testThrowThrottlingException(): Promise<void> {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({ method: 'GET', originalUrl: '/test' }),
+      }),
+    }
+    return this.throwThrottlingException(ctx as any, {
+      tracker: 'ip:1.2.3.4',
+      key: 'test-key',
+      limit: 100,
+      ttl: 60000,
+      totalHits: 101,
+      timeToExpire: 5000,
+      isBlocked: true,
+      timeToBlockExpire: 5000,
+    })
+  }
+}
+
+describe('AdminThrottlerGuard', () => {
+  describe('getTracker', () => {
+    it('uses admin:<userId> when user is authenticated', async () => {
+      const guard = new TestableAdminThrottlerGuard()
+      expect(await guard.testGetTracker({ user: { sub: 'user-123' } })).toBe('admin:user-123')
+    })
+
+    it('falls back to ip:<ip> when user has no sub', async () => {
+      const guard = new TestableAdminThrottlerGuard()
+      expect(await guard.testGetTracker({ user: {}, ip: '1.2.3.4' })).toBe('ip:1.2.3.4')
+    })
+
+    it('falls back to ip:<ip> when request has no user', async () => {
+      const guard = new TestableAdminThrottlerGuard()
+      expect(await guard.testGetTracker({ ip: '5.6.7.8' })).toBe('ip:5.6.7.8')
+    })
+
+    it('uses ip:unknown when no ip is present', async () => {
+      const guard = new TestableAdminThrottlerGuard()
+      expect(await guard.testGetTracker({})).toBe('ip:unknown')
+    })
+  })
+
+  describe('throwThrottlingException', () => {
+    it('throws ThrottlerException', async () => {
+      const guard = new TestableAdminThrottlerGuard()
+      await expect(guard.testThrowThrottlingException()).rejects.toThrow(ThrottlerException)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adiciona 14 testes unitários para os 3 módulos sem cobertura mais críticos:

**`clinic-api.service.spec.ts`** — 5 testes do SSRF guard (`buildUrl`):
- URL segura retorna resultado correto
- Segmentos dinâmicos são URI-encoded (espaços, barras)
- Template que muda o `origin` lança `ServiceUnavailableException` (SSRF bloqueado)
- Trailing slash no base URL é normalizado
- URLs com múltiplos segmentos são montadas corretamente

**`global-exception.filter.spec.ts`** — 4 testes:
- `HttpException` → status e mensagem corretos
- Erros genéricos → 500 + "Internal server error"
- Resposta sempre inclui `timestamp` (string ISO)
- Valores não-`Error` (strings) são tratados sem throw

**`admin-throttler.guard.spec.ts`** — 5 testes:
- Rastreamento por `admin:<userId>` para usuários autenticados
- Fallback por `ip:<ip>` quando não há `sub`
- Fallback por `ip:<ip>` quando não há `user`
- `ip:unknown` quando não há IP
- `throwThrottlingException` lança `ThrottlerException`

## Test plan

```
bun run test
```
→ 14/14 passando

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)