### PR TITLE
fix(security): gerar senha aleatória no seed quando SEED_ADMIN_PASSWORD é o padrão

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 import * as bcrypt from 'bcrypt'
+import { randomBytes } from 'crypto'
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_ADMIN_URL! })
 const prisma = new PrismaClient({ adapter })
@@ -52,8 +53,11 @@ async function main() {
 
   // Super admin inicial
   const adminEmail = process.env.SEED_ADMIN_EMAIL ?? 'admin@soupelvi.com.br'
-  const adminPassword = process.env.SEED_ADMIN_PASSWORD ?? 'changeme123'
+  const DEFAULT_PASSWORD = 'changeme123'
+  const rawPassword = process.env.SEED_ADMIN_PASSWORD ?? DEFAULT_PASSWORD
+  const isDefault = rawPassword === DEFAULT_PASSWORD
 
+  const adminPassword = isDefault ? randomBytes(16).toString('hex') : rawPassword
   const passwordHash = await bcrypt.hash(adminPassword, 12)
 
   await prisma.adminUser.upsert({
@@ -68,7 +72,12 @@ async function main() {
   })
 
   console.log(`✅ Admin criado: ${adminEmail}`)
-  console.log('⚠️  Troque a senha do admin após o primeiro login!')
+  if (isDefault) {
+    console.log(`🔑 Senha gerada automaticamente: ${adminPassword}`)
+    console.log('⚠️  Guarde essa senha agora — ela não será exibida novamente!')
+  } else {
+    console.log('⚠️  Troque a senha do admin após o primeiro login!')
+  }
 }
 
 main()

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -73,8 +73,8 @@ async function main() {
 
   console.log(`✅ Admin criado: ${adminEmail}`)
   if (isDefault) {
-    console.log(`🔑 Senha gerada automaticamente: ${adminPassword}`)
-    console.log('⚠️  Guarde essa senha agora — ela não será exibida novamente!')
+    console.log('🔑 Uma senha aleatória foi gerada automaticamente para o admin.')
+    console.log('⚠️  Defina/rotacione a senha por um canal seguro antes de uso em produção.')
   } else {
     console.log('⚠️  Troque a senha do admin após o primeiro login!')
   }


### PR DESCRIPTION
Quando `SEED_ADMIN_PASSWORD` não está definido (ou é igual ao valor padrão `changeme123`), o seed agora gera `randomBytes(16).toString('hex')` e imprime a senha no stdout uma única vez.

Se a env var for definida com um valor customizado, o comportamento anterior é mantido.

## Mudanças
- `backend/prisma/seed.ts`: detecta senha padrão → gera aleatória → imprime com aviso de única exibição

Closes #82