### PR TITLE
fix(security): configurar CSP explícito no helmet

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -18,7 +18,24 @@ async function bootstrap() {
     throw new Error('CORS_ORIGIN must be set to a production domain in production environment')
   }
 
-  app.use(helmet())
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"], // Swagger UI requires inline styles
+          imgSrc: ["'self'", 'data:'],
+          connectSrc: ["'self'"],
+          frameAncestors: ["'none'"],
+          objectSrc: ["'none'"],
+          baseUri: ["'self'"],
+        },
+      },
+      crossOriginResourcePolicy: { policy: 'same-site' },
+      referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    }),
+  )
   app.use(cookieParser())
   app.enableCors({ origin: corsOrigin, credentials: true })
 


### PR DESCRIPTION
Substitui `helmet()` sem argumentos por uma policy restrita e explícita.

## Mudanças
- `frameAncestors: 'none'` — bloqueia clickjacking
- `objectSrc: 'none'` — bloqueia plugins (Flash, etc.)
- `styleSrc: 'unsafe-inline'` — necessário apenas para o Swagger UI
- `crossOriginResourcePolicy: same-site`
- `referrerPolicy: strict-origin-when-cross-origin`

## Critérios validados
- `Content-Security-Policy` presente na resposta do endpoint `/api/admin/version`
- Swagger UI em `/api/admin/docs` renderiza sem erros de CSP (apenas em dev)

Closes #49