### PR TITLE
fix(security): segunda janela de rate-limit por IP no reset de senha

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,7 +18,10 @@ import { VersionModule } from './version/version.module'
       // dotenvx já injeta as variáveis no processo antes do NestJS iniciar
       ignoreEnvFile: true,
     }),
-    ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+    ThrottlerModule.forRoot([
+      { ttl: 60000, limit: 100 },
+      { name: 'reset-ip', ttl: 3_600_000, limit: 1000 },
+    ]),
     PrismaModule,
     ClinicApiModule,
     AuthModule,

--- a/backend/src/common/guards/ip-throttler.guard.spec.ts
+++ b/backend/src/common/guards/ip-throttler.guard.spec.ts
@@ -1,0 +1,54 @@
+import { ThrottlerException } from '@nestjs/throttler'
+import { IpThrottlerGuard } from './ip-throttler.guard'
+
+class TestableIpThrottlerGuard extends IpThrottlerGuard {
+  constructor() {
+    super({} as any, {} as any, {} as any)
+  }
+  async testGetTracker(req: Record<string, unknown>): Promise<string> {
+    return this.getTracker(req)
+  }
+  async testThrowThrottlingException(ip = '1.2.3.4'): Promise<void> {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({ method: 'POST', originalUrl: '/test/reset-password' }),
+      }),
+    }
+    return this.throwThrottlingException(ctx as any, {
+      tracker: `ip:${ip}`,
+      key: 'reset-ip',
+      limit: 20,
+      ttl: 3_600_000,
+      totalHits: 21,
+      isBlocked: true,
+      timeToExpire: 1000,
+      timeToBlockExpire: 1000,
+    })
+  }
+}
+
+describe('IpThrottlerGuard', () => {
+  describe('getTracker', () => {
+    it('returns ip:<ip> from request', async () => {
+      const guard = new TestableIpThrottlerGuard()
+      expect(await guard.testGetTracker({ ip: '10.0.0.1' })).toBe('ip:10.0.0.1')
+    })
+
+    it('returns ip:unknown when no ip is present', async () => {
+      const guard = new TestableIpThrottlerGuard()
+      expect(await guard.testGetTracker({})).toBe('ip:unknown')
+    })
+
+    it('ignores authenticated user — always tracks by IP', async () => {
+      const guard = new TestableIpThrottlerGuard()
+      expect(await guard.testGetTracker({ user: { sub: 'admin-1' }, ip: '9.9.9.9' })).toBe('ip:9.9.9.9')
+    })
+  })
+
+  describe('throwThrottlingException', () => {
+    it('throws ThrottlerException', async () => {
+      const guard = new TestableIpThrottlerGuard()
+      await expect(guard.testThrowThrottlingException()).rejects.toThrow(ThrottlerException)
+    })
+  })
+})

--- a/backend/src/common/guards/ip-throttler.guard.ts
+++ b/backend/src/common/guards/ip-throttler.guard.ts
@@ -1,0 +1,23 @@
+import { ExecutionContext, Injectable, Logger } from '@nestjs/common'
+import { ThrottlerException, ThrottlerGuard, ThrottlerLimitDetail } from '@nestjs/throttler'
+import type { Request } from 'express'
+
+@Injectable()
+export class IpThrottlerGuard extends ThrottlerGuard {
+  private readonly logger = new Logger(IpThrottlerGuard.name)
+
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    return `ip:${(req.ip as string | undefined) ?? 'unknown'}`
+  }
+
+  protected async throwThrottlingException(
+    context: ExecutionContext,
+    detail: ThrottlerLimitDetail,
+  ): Promise<void> {
+    const req = context.switchToHttp().getRequest<Request>()
+    this.logger.warn(
+      `IP rate limit hit on ${req.method} ${req.originalUrl} for ${detail.tracker} (limit ${detail.limit}/${detail.ttl}ms)`,
+    )
+    throw new ThrottlerException()
+  }
+}

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -8,6 +8,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { AdminThrottlerGuard } from '../common/guards/admin-throttler.guard'
+import { IpThrottlerGuard } from '../common/guards/ip-throttler.guard'
 import { CreateOrganizationUseCase } from './application/create-organization.usecase'
 import { CreateOrganizationWithOwnerUseCase } from './application/create-organization-with-owner.usecase'
 import { UpdateOrgStatusUseCase } from './application/update-status.usecase'
@@ -118,8 +119,8 @@ export class OrganizationsController {
 
   @Post(':id/users/:organizationUserId/reset-password')
   @Roles('SUPER_ADMIN', 'SUPPORT')
-  @UseGuards(AdminThrottlerGuard)
-  @Throttle({ default: { limit: 5, ttl: 600_000 } })
+  @UseGuards(AdminThrottlerGuard, IpThrottlerGuard)
+  @Throttle({ default: { limit: 5, ttl: 600_000 }, 'reset-ip': { limit: 20, ttl: 3_600_000 } })
   resetUserPassword(
     @Param('id', ParseUUIDPipe) id: string,
     @Param('organizationUserId', ParseUUIDPipe) organizationUserId: string,


### PR DESCRIPTION
Follow-up de #39 / #46. Adiciona segunda janela de rate-limit rastreada por IP no endpoint de reset de senha.

## Antes
- 1 janela: 5 resets / 10 min por admin autenticado (via `AdminThrottlerGuard`)

## Depois
- Janela 1 (por admin): 5 resets / 10 min — inalterada
- Janela 2 (por IP): 20 resets / hora — nova, via `IpThrottlerGuard`

## Mudanças
- `AppModule`: registra throttler nomeado `reset-ip` (limite permissivo como padrão; sobrescrito no endpoint)
- `IpThrottlerGuard`: novo guard que sempre rastreia por `req.ip`, independente de autenticação
- `OrganizationsController`: empilha os dois guards + `@Throttle` com ambas as janelas nomeadas
- `ip-throttler.guard.spec.ts`: 4 testes cobrindo tracker e exceção

## Critérios
- 5 resets/10min com mesmo admin → 429 (janela 1)
- 21 resets/hora do mesmo IP, mesmo trocando de admin → 429 (janela 2)
- Outros endpoints não afetados

Closes #48