### PR TITLE
fix: substituir Partial<CreateSubscriptionDto> por UpdateSubscriptionDto tipado

### DIFF
--- a/backend/src/subscriptions/dto/update-subscription.dto.ts
+++ b/backend/src/subscriptions/dto/update-subscription.dto.ts
@@ -1,0 +1,14 @@
+import { IsDateString, IsEnum, IsOptional } from 'class-validator'
+import { ApiPropertyOptional } from '@nestjs/swagger'
+
+export class UpdateSubscriptionDto {
+  @ApiPropertyOptional({ description: 'Nova data fim do trial (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  trialEndsAt?: string
+
+  @ApiPropertyOptional({ enum: ['TRIAL', 'ACTIVE', 'SUSPENDED', 'CANCELED'] })
+  @IsOptional()
+  @IsEnum(['TRIAL', 'ACTIVE', 'SUSPENDED', 'CANCELED'])
+  status?: string
+}

--- a/backend/src/subscriptions/subscriptions.controller.ts
+++ b/backend/src/subscriptions/subscriptions.controller.ts
@@ -5,6 +5,7 @@ import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { SubscriptionsService } from './subscriptions.service'
 import { CreateSubscriptionDto } from './dto/create-subscription.dto'
+import { UpdateSubscriptionDto } from './dto/update-subscription.dto'
 
 @ApiTags('subscriptions')
 @ApiBearerAuth()
@@ -47,7 +48,7 @@ export class SubscriptionsController {
 
   @Patch(':id')
   @Roles('SUPER_ADMIN', 'FINANCE')
-  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: Partial<CreateSubscriptionDto>) {
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateSubscriptionDto) {
     return this.subscriptionsService.update(id, dto)
   }
 

--- a/backend/src/subscriptions/subscriptions.service.ts
+++ b/backend/src/subscriptions/subscriptions.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { ClinicApiService } from '../clinic-api/clinic-api.service'
 import { CreateSubscriptionDto } from './dto/create-subscription.dto'
+import { UpdateSubscriptionDto } from './dto/update-subscription.dto'
 
 @Injectable()
 export class SubscriptionsService {
@@ -76,8 +77,14 @@ export class SubscriptionsService {
     })
   }
 
-  async update(id: string, data: Partial<CreateSubscriptionDto>) {
+  async update(id: string, dto: UpdateSubscriptionDto) {
     await this.findOne(id)
-    return this.prisma.subscription.update({ where: { id }, data })
+    return this.prisma.subscription.update({
+      where: { id },
+      data: {
+        ...(dto.trialEndsAt !== undefined && { trialEndsAt: new Date(dto.trialEndsAt) }),
+        ...(dto.status !== undefined && { status: dto.status as any }),
+      },
+    })
   }
 }


### PR DESCRIPTION
`PATCH /subscriptions/:id` aceitava `Partial<CreateSubscriptionDto>`, permitindo que qualquer campo (incluindo `organizationId` e `planId`) fosse sobrescrito diretamente, bypassando invariantes de domínio.

## Mudanças
- `UpdateSubscriptionDto`: aceita apenas `trialEndsAt` e `status`
- `SubscriptionsController`: tipado com `UpdateSubscriptionDto`
- `SubscriptionsService.update`: constrói o `data` explicitamente sem spread direto

## Campos bloqueados via PATCH
- `organizationId` — nunca deve ser alterado
- `planId` — mudança de plano deve ter seu próprio fluxo

Closes #79