### PR TITLE
feat: ClassSerializerInterceptor global e AdminUserResponseDto

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto'
 import { PrismaService } from '../prisma/prisma.service'
 import { LoginDto } from './dto/login.dto'
 import { ChangePasswordDto } from './dto/change-password.dto'
+import { AdminUserResponseDto } from './dto/admin-user-response.dto'
 import { JwtRefreshPayload } from './strategies/jwt-refresh.strategy'
 
 const REFRESH_TTL_DAYS = 7
@@ -43,24 +44,18 @@ export class AuthService {
 
     return {
       ...tokens,
-      user: {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        role: user.role,
-      },
+      user: new AdminUserResponseDto(user as Record<string, unknown>),
     }
   }
 
   async getMe(userId: string) {
     const user = await this.prisma.adminUser.findUnique({
       where: { id: userId },
-      select: { id: true, name: true, email: true, role: true, createdAt: true },
     })
 
     if (!user) throw new UnauthorizedException()
 
-    return user
+    return new AdminUserResponseDto(user as Record<string, unknown>)
   }
 
   async rotateRefreshToken(userId: string, jti: string): Promise<IssuedTokens> {

--- a/backend/src/auth/dto/admin-user-response.dto.ts
+++ b/backend/src/auth/dto/admin-user-response.dto.ts
@@ -1,0 +1,31 @@
+import { Exclude, Expose } from 'class-transformer'
+import { ApiProperty } from '@nestjs/swagger'
+
+@Exclude()
+export class AdminUserResponseDto {
+  @Expose()
+  @ApiProperty()
+  id: string
+
+  @Expose()
+  @ApiProperty()
+  name: string
+
+  @Expose()
+  @ApiProperty()
+  email: string
+
+  @Expose()
+  @ApiProperty()
+  role: string
+
+  @Expose()
+  @ApiProperty()
+  createdAt: Date
+
+  // passwordHash, active, and AdminRefreshToken relations are never exposed
+
+  constructor(partial: Record<string, unknown>) {
+    Object.assign(this, partial)
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,5 @@
-import { NestFactory } from '@nestjs/core'
-import { ValidationPipe, BadRequestException } from '@nestjs/common'
+import { NestFactory, Reflector } from '@nestjs/core'
+import { ValidationPipe, BadRequestException, ClassSerializerInterceptor } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import * as cookieParser from 'cookie-parser'
@@ -40,6 +40,7 @@ async function bootstrap() {
   app.enableCors({ origin: corsOrigin, credentials: true })
 
   app.useGlobalFilters(new GlobalExceptionFilter())
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)))
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
Endpoints retornavam objetos Prisma brutos sem filtragem de campos internos. Esta PR adiciona a camada de serialização padrão do NestJS.

## Mudanças

### `main.ts`
- `ClassSerializerInterceptor` registrado globalmente via `app.useGlobalInterceptors`
- Garante que qualquer response DTO com `@Exclude()` nunca vaza campos internos, independentemente de onde o endpoint é implementado

### `AdminUserResponseDto`
- Classe com `@Exclude()` no nível da classe e `@Expose()` apenas em: `id`, `name`, `email`, `role`, `createdAt`
- `passwordHash`, `active`, tokens de refresh — nunca serializados

### `AuthService`
- `login` e `getMe` retornam `new AdminUserResponseDto(user)` em vez de objetos Prisma brutos
- `getMe` removeu o `select` manual (agora controlado pelo DTO)

## Por que não limitar os `include` de subscriptions
O frontend admin usa `clinicExternalId` da organization aninhada para navegar entre organização ↔ clínica. Remover esse campo quebraria a UI.

Closes #78