### PR TITLE
chore(test): silenciar NestJS Logger durante os testes

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test/jest-setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },

--- a/backend/src/test/jest-setup.ts
+++ b/backend/src/test/jest-setup.ts
@@ -1,0 +1,9 @@
+import { Logger } from '@nestjs/common'
+
+// Suppress NestJS Logger output during tests to keep the test runner output clean.
+// The logger is still called (behaviour is tested), but nothing is printed to stdout/stderr.
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined)
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined)
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined)
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined)
+jest.spyOn(Logger.prototype, 'verbose').mockImplementation(() => undefined)


### PR DESCRIPTION
Os logs do NestJS (`[Nest] ERROR`, `[Nest] WARN`, etc.) poluíam o output do CI mesmo com todos os testes passando, porque o `Logger` do código de produção é chamado durante as specs.

## Solução
`setupFiles` global no `jest.config.ts` aponta para `src/test/jest-setup.ts`, que mocka todos os métodos do `Logger.prototype` com `jest.spyOn(...).mockImplementation(() => undefined)`.

- Comportamento testado: inalterado (os mocks ainda registram chamadas para `toHaveBeenCalled` etc.)
- Output do CI: limpo

## Antes
```
[Nest] 2487 ERROR [GlobalExceptionFilter] Error: something broke
[Nest] 2487 ERROR [GlobalExceptionFilter] some string error
[Nest] 2486 ERROR [CreateOrganizationWithOwnerUseCase] Local persistence failed...
```

## Depois
Apenas as linhas `PASS / FAIL` e o sumário.