### PR TITLE
chore: request correlation IDs e AppLogger estruturado

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { ThrottlerModule } from '@nestjs/throttler'
 import { PrismaModule } from './prisma/prisma.module'
@@ -10,6 +10,7 @@ import { InvoicesModule } from './invoices/invoices.module'
 import { MetricsModule } from './metrics/metrics.module'
 import { ClinicApiModule } from './clinic-api/clinic-api.module'
 import { VersionModule } from './version/version.module'
+import { CorrelationIdMiddleware } from './common/correlation/correlation-id.middleware'
 
 @Module({
   imports: [
@@ -33,4 +34,8 @@ import { VersionModule } from './version/version.module'
     VersionModule,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*')
+  }
+}

--- a/backend/src/common/correlation/correlation-id.middleware.spec.ts
+++ b/backend/src/common/correlation/correlation-id.middleware.spec.ts
@@ -1,0 +1,50 @@
+import { CorrelationIdMiddleware, CORRELATION_HEADER } from './correlation-id.middleware'
+import { correlationStorage } from './correlation.context'
+
+const makeReqRes = (headerValue?: string) => {
+  const headers: Record<string, string> = {}
+  if (headerValue) headers[CORRELATION_HEADER] = headerValue
+  const req = { headers } as any
+  const res = { setHeader: jest.fn() } as any
+  return { req, res }
+}
+
+describe('CorrelationIdMiddleware', () => {
+  let middleware: CorrelationIdMiddleware
+
+  beforeEach(() => {
+    middleware = new CorrelationIdMiddleware()
+  })
+
+  it('generates a UUID when no header is present', (done) => {
+    const { req, res } = makeReqRes()
+    middleware.use(req, res, () => {
+      const id = correlationStorage.getStore()
+      expect(id).toMatch(/^[\da-f-]{36}$/)
+      expect(res.setHeader).toHaveBeenCalledWith(CORRELATION_HEADER, id)
+      done()
+    })
+  })
+
+  it('reuses the header value when present', (done) => {
+    const { req, res } = makeReqRes('my-trace-id-123')
+    middleware.use(req, res, () => {
+      expect(correlationStorage.getStore()).toBe('my-trace-id-123')
+      expect(res.setHeader).toHaveBeenCalledWith(CORRELATION_HEADER, 'my-trace-id-123')
+      done()
+    })
+  })
+
+  it('generates different IDs for each call (request isolation)', (done) => {
+    const { req: req1, res: res1 } = makeReqRes()
+    const { req: req2, res: res2 } = makeReqRes()
+    let id1: string | undefined
+    let id2: string | undefined
+    middleware.use(req1, res1, () => { id1 = correlationStorage.getStore() })
+    middleware.use(req2, res2, () => { id2 = correlationStorage.getStore() })
+    expect(id1).toBeDefined()
+    expect(id2).toBeDefined()
+    expect(id1).not.toBe(id2)
+    done()
+  })
+})

--- a/backend/src/common/correlation/correlation-id.middleware.ts
+++ b/backend/src/common/correlation/correlation-id.middleware.ts
@@ -1,0 +1,15 @@
+import { Injectable, NestMiddleware } from '@nestjs/common'
+import { randomUUID } from 'crypto'
+import { Request, Response, NextFunction } from 'express'
+import { correlationStorage } from './correlation.context'
+
+export const CORRELATION_HEADER = 'x-correlation-id'
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const id = (req.headers[CORRELATION_HEADER] as string | undefined) ?? randomUUID()
+    res.setHeader(CORRELATION_HEADER, id)
+    correlationStorage.run(id, next)
+  }
+}

--- a/backend/src/common/correlation/correlation.context.ts
+++ b/backend/src/common/correlation/correlation.context.ts
@@ -1,0 +1,7 @@
+import { AsyncLocalStorage } from 'async_hooks'
+
+export const correlationStorage = new AsyncLocalStorage<string>()
+
+export function getCorrelationId(): string {
+  return correlationStorage.getStore() ?? '-'
+}

--- a/backend/src/common/filters/global-exception.filter.ts
+++ b/backend/src/common/filters/global-exception.filter.ts
@@ -1,5 +1,6 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Logger } from '@nestjs/common'
 import { Response } from 'express'
+import { getCorrelationId } from '../correlation/correlation.context'
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
@@ -22,6 +23,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     response.status(status).json({
       statusCode: status,
       message,
+      correlationId: getCorrelationId(),
       timestamp: new Date().toISOString(),
     })
   }

--- a/backend/src/common/logger/app-logger.service.ts
+++ b/backend/src/common/logger/app-logger.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, LoggerService } from '@nestjs/common'
+import { getCorrelationId } from '../correlation/correlation.context'
+
+@Injectable()
+export class AppLogger implements LoggerService {
+  private fmt(message: unknown): string {
+    const cid = getCorrelationId()
+    return `[${cid}] ${message}`
+  }
+
+  log(message: unknown, context?: string): void {
+    const out = this.fmt(message)
+    context ? console.log(`[${context}] ${out}`) : console.log(out)
+  }
+
+  error(message: unknown, trace?: string, context?: string): void {
+    const out = this.fmt(message)
+    context ? console.error(`[${context}] ${out}`) : console.error(out)
+    if (trace) console.error(trace)
+  }
+
+  warn(message: unknown, context?: string): void {
+    const out = this.fmt(message)
+    context ? console.warn(`[${context}] ${out}`) : console.warn(out)
+  }
+
+  debug(message: unknown, context?: string): void {
+    const out = this.fmt(message)
+    context ? console.debug(`[${context}] ${out}`) : console.debug(out)
+  }
+
+  verbose(message: unknown, context?: string): void {
+    const out = this.fmt(message)
+    context ? console.log(`[VERBOSE][${context}] ${out}`) : console.log(`[VERBOSE] ${out}`)
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,9 +6,11 @@ import * as cookieParser from 'cookie-parser'
 import helmet from 'helmet'
 import { AppModule } from './app.module'
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter'
+import { AppLogger } from './common/logger/app-logger.service'
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule)
+  const appLogger = new AppLogger()
+  const app = await NestFactory.create(AppModule, { logger: appLogger })
 
   const config = app.get(ConfigService)
   const port = config.get<number>('PORT', 3001)


### PR DESCRIPTION
Sem correlation ID era impossível reconstruir um fluxo multi-step em produção (ex: createClinic → upsertPerson → $transaction).

## O que foi implementado

### `CorrelationIdMiddleware`
- Aplicado em todas as rotas via `AppModule`
- Gera `randomUUID()` por request, ou reutiliza o header `x-correlation-id` quando enviado pelo cliente (útil para rastrear chamadas originadas de outro serviço)
- Devolve o ID como header `x-correlation-id` na resposta

### `correlationStorage` (`AsyncLocalStorage`)
- Propaga o ID por todo o ciclo de vida do request sem passar por parâmetros
- `getCorrelationId()` retorna `'-'` fora de um contexto de request (ex: startup logs)

### `AppLogger`
- Implementa `LoggerService` e é registrado como logger global via `NestFactory.create(AppModule, { logger: appLogger })`
- Prefixa cada linha com `[<correlationId>]`, tornando `grep <cid>` suficiente para reconstruir qualquer request em produção

### `GlobalExceptionFilter`
- Inclui `correlationId` no body de erro 5xx para facilitar busca nos logs

## Exemplo de log em produção
```
[a3f2c1d4-...] [ClinicApiService] Creating clinic: Clínica A
[a3f2c1d4-...] [CreateOrganizationWithOwnerUseCase] Local persistence failed...
[a3f2c1d4-...] [ClinicApiService] Updating clinic ... access → BLOCKED
```

Closes #81