### PR TITLE
fix(plans): converter Decimal do Prisma para number antes da serialização JSON

### DIFF
--- a/backend/src/common/interceptors/decimal-serializer.interceptor.ts
+++ b/backend/src/common/interceptors/decimal-serializer.interceptor.ts
@@ -1,0 +1,25 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+function coerceDecimals(value: unknown): unknown {
+  if (value === null || value === undefined) return value
+  // Prisma Decimal (decimal.js) exposes toNumber()
+  if (typeof value === 'object' && typeof (value as { toNumber?: unknown }).toNumber === 'function') {
+    return (value as { toNumber: () => number }).toNumber()
+  }
+  if (Array.isArray(value)) return value.map(coerceDecimals)
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, coerceDecimals(v)]),
+    )
+  }
+  return value
+}
+
+@Injectable()
+export class DecimalSerializerInterceptor implements NestInterceptor {
+  intercept(_ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(map(coerceDecimals))
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory, Reflector } from '@nestjs/core'
 import { ValidationPipe, BadRequestException, ClassSerializerInterceptor } from '@nestjs/common'
+import { DecimalSerializerInterceptor } from './common/interceptors/decimal-serializer.interceptor'
 import { ConfigService } from '@nestjs/config'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import * as cookieParser from 'cookie-parser'
@@ -42,7 +43,10 @@ async function bootstrap() {
   app.enableCors({ origin: corsOrigin, credentials: true })
 
   app.useGlobalFilters(new GlobalExceptionFilter())
-  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)))
+  app.useGlobalInterceptors(
+    new DecimalSerializerInterceptor(),
+    new ClassSerializerInterceptor(app.get(Reflector)),
+  )
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -6,7 +6,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatCurrency(value: number) {
-  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value)
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(Number(value))
 }
 
 export function formatDate(date: string | Date) {

--- a/frontend/src/pages/OrganizationDetail.tsx
+++ b/frontend/src/pages/OrganizationDetail.tsx
@@ -176,7 +176,7 @@ export function OrganizationDetailPage() {
             <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500, marginBottom: 6 }}>MRR contratado</div>
             <div style={{ fontFamily: 'var(--font-display)', fontSize: 24, fontWeight: 600, letterSpacing: '-0.02em', color: 'var(--text)', fontVariantNumeric: 'tabular-nums' }}>
               <span style={{ fontSize: 14, color: 'var(--text-muted)', fontWeight: 500, marginRight: 2 }}>R$</span>
-              {activeSubscription.plan?.priceMonthly.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) ?? '—'}
+              {activeSubscription.plan ? Number(activeSubscription.plan.priceMonthly).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '—'}
             </div>
             <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>
               Recorrência mensal · plano {activeSubscription.plan?.name}

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -74,7 +74,7 @@ function PlanCard({ plan, isHighlight }: { plan: Plan; isHighlight: boolean }) {
         <div style={{ marginTop: 18, display: 'flex', alignItems: 'baseline', gap: 4 }}>
           <span style={{ fontSize: 13, color: 'var(--text-muted)', fontWeight: 500 }}>R$</span>
           <span className="num" style={{ fontSize: 36, fontWeight: 600, letterSpacing: '-0.025em', lineHeight: 1, fontVariantNumeric: 'tabular-nums', fontFamily: 'var(--font-display)', color: 'var(--text)' }}>
-            {plan.priceMonthly.toLocaleString('pt-BR')}
+            {Math.trunc(Number(plan.priceMonthly)).toLocaleString('pt-BR')}
           </span>
           <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>,00 / mês</span>
         </div>


### PR DESCRIPTION
## Summary

- Cria `DecimalSerializerInterceptor` em `common/interceptors/` — percorre recursivamente a resposta e converte qualquer `Decimal` (detectado por `.toNumber()`) para `number` antes do `JSON.stringify`. Registrado globalmente em `main.ts` antes do `ClassSerializerInterceptor`.
- `formatCurrency` passa o valor por `Number()` como blindagem adicional.
- Corrige chamadas diretas a `.toLocaleString()` em `priceMonthly` em `Plans.tsx` e `OrganizationDetail.tsx`.

## Test plan

- [ ] Acessar `/plans` — valores exibidos corretamente (ex. `R$ 199,00 /mês`)
- [ ] Acessar detalhe de uma organização com assinatura ativa — MRR contratado exibido corretamente
- [ ] `tsc --noEmit` sem erros (backend e frontend) ✅

Closes #104