### PR TITLE
feat(metrics): séries históricas para sparklines e deltas dos KPI tiles

### DIFF
--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -32,6 +32,13 @@ export class MetricsController {
     return this.metricsService.getConversionFunnel(Number(days) || 90)
   }
 
+  @Get('kpi-trends')
+  @Roles('SUPER_ADMIN', 'FINANCE')
+  @ApiQuery({ name: 'months', required: false, type: Number })
+  getKpiTrends(@Query('months') months?: number) {
+    return this.metricsService.getKpiTrends(Math.min(Number(months) || 12, 24))
+  }
+
   @Get('organizations')
   @Roles('SUPER_ADMIN', 'FINANCE')
   @ApiQuery({ name: 'period', required: false, enum: ['week', 'month', 'year'] })

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -91,6 +91,81 @@ export class MetricsService {
     }
   }
 
+  async getKpiTrends(months: number) {
+    const now = new Date()
+    // Slot 0 = oldest, slot N-1 = most recent (current month)
+    const slots = Array.from({ length: months }, (_, i) => {
+      const offset = months - 1 - i
+      const start = new Date(now.getFullYear(), now.getMonth() - offset, 1)
+      const end = new Date(now.getFullYear(), now.getMonth() - offset + 1, 0, 23, 59, 59, 999)
+      return { start, end }
+    })
+
+    const windowStart = slots[0].start
+
+    const [paidInvoices, orgsCreated, trialsCreated, overdueByDue] =
+      await this.prisma.$transaction([
+        this.prisma.invoice.findMany({
+          where: { status: 'PAID', paidAt: { gte: windowStart } },
+          select: { amount: true, paidAt: true },
+          take: 50000,
+        }),
+        this.prisma.organization.findMany({
+          where: { createdAt: { gte: windowStart } },
+          select: { createdAt: true },
+          take: 50000,
+        }),
+        this.prisma.subscription.findMany({
+          where: { startDate: { gte: windowStart } },
+          select: { startDate: true },
+          take: 50000,
+        }),
+        this.prisma.invoice.findMany({
+          where: { status: 'OVERDUE', dueDate: { gte: windowStart } },
+          select: { dueDate: true },
+          take: 50000,
+        }),
+      ])
+
+    const inSlot = (date: Date, slot: { start: Date; end: Date }) =>
+      date >= slot.start && date <= slot.end
+
+    const mrr = slots.map((s) =>
+      paidInvoices.filter((i) => i.paidAt && inSlot(i.paidAt, s)).reduce((acc, i) => acc + Number(i.amount), 0),
+    )
+    const activeOrgs = slots.map((s) =>
+      orgsCreated.filter((o) => o.createdAt <= s.end).length,
+    )
+    const trialOrgs = slots.map((s) =>
+      trialsCreated.filter((sub) => inSlot(sub.startDate, s)).length,
+    )
+    const overdueInvoices = slots.map((s) =>
+      overdueByDue.filter((i) => inSlot(i.dueDate, s)).length,
+    )
+
+    const last = months - 1
+    const prev = months - 2
+
+    const delta = (arr: number[], i: number, j: number) => arr[j] - arr[i]
+    const pctDelta = (arr: number[], i: number, j: number) =>
+      arr[i] === 0 ? 0 : Math.round(((arr[j] - arr[i]) / arr[i]) * 1000) / 10
+
+    return {
+      months,
+      mrr,
+      activeOrgs,
+      trialOrgs,
+      // suspendedOrgs is a snapshot metric; not derivable from createdAt alone
+      suspendedOrgs: Array(months).fill(0) as number[],
+      overdueInvoices,
+      mrrDelta: pctDelta(mrr, prev, last),
+      activeOrgsDelta: delta(activeOrgs, prev, last),
+      trialOrgsDelta: delta(trialOrgs, prev, last),
+      suspendedOrgsDelta: 0,
+      overdueInvoicesDelta: delta(overdueInvoices, prev, last),
+    }
+  }
+
   async getOrganizationsByPeriod(period: 'week' | 'month' | 'year' = 'month') {
     const now = new Date()
     const ranges = {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,10 +2,18 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { api } from '@/lib/api'
 import { formatCurrency } from '@/lib/utils'
-import type { MetricsSummary, Organization, Invoice, PaginatedResponse, ConversionFunnel } from '@/types/admin'
+import type { MetricsSummary, Organization, Invoice, PaginatedResponse, ConversionFunnel, KpiTrends } from '@/types/admin'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Sparkline, OrgAvatar, StatusPill, PageHeader, Card, CardHeader } from '@/components/ui/ds'
 
+function fmtDelta(value: number, pct = false): { label: string; tone: 'up' | 'down' | 'flat' } {
+  if (value === 0) return { label: '—', tone: 'flat' }
+  const abs = Math.abs(value)
+  const label = pct
+    ? `${value > 0 ? '+' : '−'}${abs.toLocaleString('pt-BR', { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`
+    : `${value > 0 ? '+' : '−'}${abs}`
+  return { label, tone: value > 0 ? 'up' : 'down' }
+}
 
 const DownloadIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" style={{ width: 14, height: 14 }}>
@@ -86,6 +94,11 @@ export function DashboardPage() {
     queryFn: () => api.get('/metrics/funnel').then((r) => r.data),
   })
 
+  const { data: trends } = useQuery<KpiTrends>({
+    queryKey: ['metrics-kpi-trends'],
+    queryFn: () => api.get('/metrics/kpi-trends').then((r) => r.data),
+  })
+
   const { data: recentOrgsResp } = useQuery<PaginatedResponse<Organization>>({
     queryKey: ['organizations', '', '', 1, 5],
     queryFn: () => api.get('/organizations', { params: { limit: 5 } }).then((r) => r.data),
@@ -138,31 +151,47 @@ export function DashboardPage() {
       />
 
       {/* KPI strip */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr 1fr 1fr 1fr', background: 'var(--surface)', border: '1px solid var(--ds-border)', borderRadius: 12, overflow: 'hidden', boxShadow: 'var(--shadow-xs)' }}>
-        <KpiTile
-          label="MRR (receita mensal)" currency
-          value={mrr.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-          delta="—" deltaTone="flat" trend={[]} color="var(--ok-ink)"
-        />
-        <KpiTile label="Organizações ativas" value={String(data?.activeOrgs ?? 0)} delta="—" deltaTone="flat" trend={[]} color="var(--info-ink)"/>
-        <KpiTile label="Em trial" value={String(data?.trialOrgs ?? 0)} delta="—" deltaTone="flat" trend={[]} color="var(--warn-ink)"/>
-        <KpiTile label="Suspensas" value={String(data?.suspendedOrgs ?? 0)} delta="—" deltaTone="flat" trend={[]} color="var(--warn-ink)"/>
-        <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
-          <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500 }}>Faturas vencidas</div>
-          <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 600, letterSpacing: '-0.022em', color: 'var(--danger)', fontVariantNumeric: 'tabular-nums', lineHeight: '32px' }}>
-            {data?.overdueInvoices ?? 0}
+      {(() => {
+        const mrrD = fmtDelta(trends?.mrrDelta ?? 0, true)
+        const activeD = fmtDelta(trends?.activeOrgsDelta ?? 0)
+        const trialD = fmtDelta(trends?.trialOrgsDelta ?? 0)
+        const overdueD = fmtDelta(trends?.overdueInvoicesDelta ?? 0)
+        return (
+          <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr 1fr 1fr 1fr', background: 'var(--surface)', border: '1px solid var(--ds-border)', borderRadius: 12, overflow: 'hidden', boxShadow: 'var(--shadow-xs)' }}>
+            <KpiTile
+              label="MRR (receita mensal)" currency
+              value={mrr.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+              delta={mrrD.label} deltaTone={mrrD.tone} trend={trends?.mrr ?? []} color="var(--ok-ink)"
+            />
+            <KpiTile label="Organizações ativas" value={String(data?.activeOrgs ?? 0)}
+              delta={activeD.label} deltaTone={activeD.tone} trend={trends?.activeOrgs ?? []} color="var(--info-ink)"/>
+            <KpiTile label="Em trial" value={String(data?.trialOrgs ?? 0)}
+              delta={trialD.label} deltaTone={trialD.tone} trend={trends?.trialOrgs ?? []} color="var(--warn-ink)"/>
+            <KpiTile label="Suspensas" value={String(data?.suspendedOrgs ?? 0)}
+              delta="—" deltaTone="flat" trend={[]} color="var(--warn-ink)"/>
+            <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500 }}>Faturas vencidas</div>
+              <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 600, letterSpacing: '-0.022em', color: 'var(--danger)', fontVariantNumeric: 'tabular-nums', lineHeight: '32px' }}>
+                {data?.overdueInvoices ?? 0}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, fontVariantNumeric: 'tabular-nums', fontWeight: 500 }}>
+                <span style={{
+                  display: 'inline-flex', alignItems: 'center', padding: '1px 5px', borderRadius: 4,
+                  fontFamily: 'var(--font-mono)', fontSize: 11,
+                  background: overdueD.tone === 'up' ? 'var(--danger-soft)' : overdueD.tone === 'down' ? 'var(--ok-soft)' : 'var(--surface-3)',
+                  color: overdueD.tone === 'up' ? 'var(--danger-ink)' : overdueD.tone === 'down' ? 'var(--ok-ink)' : 'var(--text-muted)',
+                }}>
+                  {overdueD.tone === 'up' ? '↑' : overdueD.tone === 'down' ? '↓' : '•'} {overdueD.label}
+                </span>
+                <span style={{ color: 'var(--text-faint)', fontWeight: 400 }}>vs mês anterior</span>
+              </div>
+              <div style={{ height: 30, marginTop: 4 }}>
+                <Sparkline data={trends?.overdueInvoices ?? []} color="var(--danger-ink)" height={30} />
+              </div>
+            </div>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, fontVariantNumeric: 'tabular-nums', fontWeight: 500 }}>
-            <span style={{ display: 'inline-flex', alignItems: 'center', padding: '1px 5px', borderRadius: 4, fontFamily: 'var(--font-mono)', fontSize: 11, background: 'var(--surface-3)', color: 'var(--text-muted)' }}>
-              • —
-            </span>
-            <span style={{ color: 'var(--text-faint)', fontWeight: 400 }}>vs mês anterior</span>
-          </div>
-          <div style={{ height: 30, marginTop: 4 }}>
-            <Sparkline data={[]} color="var(--danger-ink)" height={30} />
-          </div>
-        </div>
-      </div>
+        )
+      })()}
 
       {/* Funnel + recent orgs */}
       <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 16 }}>

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -78,6 +78,20 @@ export interface ConversionFunnel {
   deltaConversionRate: number
 }
 
+export interface KpiTrends {
+  months: number
+  mrr: number[]
+  activeOrgs: number[]
+  trialOrgs: number[]
+  suspendedOrgs: number[]
+  overdueInvoices: number[]
+  mrrDelta: number
+  activeOrgsDelta: number
+  trialOrgsDelta: number
+  suspendedOrgsDelta: number
+  overdueInvoicesDelta: number
+}
+
 export interface PaginatedResponse<T> {
   data: T[]
   total: number


### PR DESCRIPTION
## Summary

- `GET /api/admin/metrics/kpi-trends?months=12`: retorna arrays mensais de MRR (soma de faturas PAID por mês), novas orgs acumuladas, trials iniciados e faturas vencidas. Deltas (mês atual vs anterior) calculados no backend — MRR em %, demais em valor absoluto.
- Frontend remove todos os arrays hardcoded (`MRR_TREND`, `ACTIVE_TREND`, etc.) e deltas fixos. Introduz `fmtDelta` para formatar label e tom da badge dinamicamente.
- `suspendedOrgs` retorna array zerado enquanto não há histórico de mudanças de status (será resolvido via `OrgEvent` na issue #102).

## Notas de implementação

As contagens históricas são aproximações baseadas em `createdAt`/`paidAt`/`dueDate` — o modelo atual não tem tabela de histórico de estado. Os sparklines mostram tendências reais, não snapshots perfeitos.

## Test plan

- [ ] `GET /metrics/kpi-trends` retorna 12 arrays com 12 posições cada
- [ ] `GET /metrics/kpi-trends?months=6` retorna arrays com 6 posições
- [ ] Sparklines do dashboard renderizam com dados reais
- [ ] Badges de delta mostram `—` quando não há variação
- [ ] `tsc --noEmit` sem erros ✅

Closes #100