### PR TITLE
feat(organizations): incluir MRR por organização nas listagens

### DIFF
--- a/backend/src/organizations/domain/organization.entity.ts
+++ b/backend/src/organizations/domain/organization.entity.ts
@@ -12,4 +12,5 @@ export interface Organization {
   clinicExternalId: string | null
   createdAt: Date
   updatedAt: Date
+  mrr?: number | null
 }

--- a/backend/src/organizations/infra/prisma-organization.repository.ts
+++ b/backend/src/organizations/infra/prisma-organization.repository.ts
@@ -7,8 +7,26 @@ import { Organization } from '../domain/organization.entity'
 export class PrismaOrganizationRepository implements IOrganizationRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  private readonly activeSubInclude = {
+    subscriptions: {
+      where: { status: { in: ['ACTIVE', 'TRIAL'] as ['ACTIVE', 'TRIAL'] } },
+      include: { plan: { select: { priceMonthly: true } } },
+      take: 1,
+    },
+  } as const
+
+  private computeMrr(subs: { plan: { priceMonthly: unknown } }[]): number | null {
+    return subs[0]?.plan ? Number(subs[0].plan.priceMonthly) : null
+  }
+
   async findById(id: string): Promise<Organization | null> {
-    return this.prisma.organization.findUnique({ where: { id } }) as Promise<Organization | null>
+    const org = await this.prisma.organization.findUnique({
+      where: { id },
+      include: this.activeSubInclude,
+    })
+    if (!org) return null
+    const { subscriptions, ...rest } = org
+    return { ...rest, mrr: this.computeMrr(subscriptions) }
   }
 
   async findAll(filter: ListOrganizationsFilter): Promise<{ data: Organization[]; total: number }> {
@@ -27,11 +45,20 @@ export class PrismaOrganizationRepository implements IOrganizationRepository {
     }
 
     const [data, total] = await this.prisma.$transaction([
-      this.prisma.organization.findMany({ where, skip, take: limit, orderBy: { createdAt: 'desc' } }),
+      this.prisma.organization.findMany({
+        where, skip, take: limit, orderBy: { createdAt: 'desc' },
+        include: this.activeSubInclude,
+      }),
       this.prisma.organization.count({ where }),
     ])
 
-    return { data: data as Organization[], total }
+    return {
+      data: data.map(({ subscriptions, ...org }) => ({
+        ...org,
+        mrr: this.computeMrr(subscriptions),
+      })),
+      total,
+    }
   }
 
   async create(data: Omit<Organization, 'id' | 'createdAt' | 'updatedAt'>): Promise<Organization> {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -206,7 +206,9 @@ export function DashboardPage() {
                       : org.status === 'SUSPENDED' ? <StatusPill tone="warn">Suspensa</StatusPill>
                       : <StatusPill tone="muted">Cancelada</StatusPill>}
                   </td>
-                  <td className="num" style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12 }}>—</td>
+                  <td className="num" style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+                    {org.mrr != null ? formatCurrency(org.mrr) : '—'}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/Organizations.tsx
+++ b/frontend/src/pages/Organizations.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { api } from '@/lib/api'
-import { formatDate, formatCNPJ } from '@/lib/utils'
+import { formatDate, formatCNPJ, formatCurrency } from '@/lib/utils'
 import type { Organization, OrgStatus, PaginatedResponse } from '@/types/admin'
 import { useState } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -90,7 +90,7 @@ export function OrganizationsPage() {
                 <th style={{ width: 32 }}><input type="checkbox" style={{ accentColor: 'var(--p)' }} /></th>
                 <th>Organização</th>
                 <th>CNPJ</th>
-                <th>Plano</th>
+                <th style={{ textAlign: 'right' }}>MRR</th>
                 <th style={{ textAlign: 'right' }}>Usuários</th>
                 <th>Status</th>
                 <th>Cliente desde</th>
@@ -123,7 +123,9 @@ export function OrganizationsPage() {
                   <td style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-muted)' }}>
                     {formatCNPJ(org.document)}
                   </td>
-                  <td>—</td>
+                  <td className="num" style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-2)' }}>
+                    {org.mrr != null ? formatCurrency(org.mrr) : '—'}
+                  </td>
                   <td className="num" style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-2)' }}>—</td>
                   <td>
                     {org.status === 'ACTIVE'    ? <StatusPill tone="ok">Ativa</StatusPill>

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -21,6 +21,7 @@ export interface Organization {
   clinicExternalId: string | null
   createdAt: string
   updatedAt: string
+  mrr: number | null
 }
 
 export interface Plan {


### PR DESCRIPTION
## Summary

- `PrismaOrganizationRepository` inclui a subscription ativa/trial (status `ACTIVE` ou `TRIAL`) com o plano via `include`, e computa `mrr = Number(plan.priceMonthly)` como campo calculado antes de retornar.
- `mrr` é opcional na entidade de domínio (campo computado, não persistido no banco).
- `GET /organizations` e `GET /organizations/:id` agora retornam `mrr: number | null`.
- Dashboard: coluna MRR nas organizações recentes exibe o valor formatado.
- Listagem de organizações: coluna "Plano" substituída por "MRR" com valor real.

## Test plan

- [ ] `GET /organizations` retorna `mrr` para orgs com assinatura ativa/trial
- [ ] Orgs sem assinatura retornam `mrr: null` (exibe `—`)
- [ ] Dashboard exibe MRR formatado na tabela de orgs recentes
- [ ] `tsc --noEmit` sem erros ✅

Closes #103