### PR TITLE
fix(plans): corrigir regressão NaN no preço dos planos

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,5 @@
-import { NestFactory, Reflector } from '@nestjs/core'
-import { ValidationPipe, BadRequestException, ClassSerializerInterceptor } from '@nestjs/common'
+import { NestFactory } from '@nestjs/core'
+import { ValidationPipe, BadRequestException } from '@nestjs/common'
 import { DecimalSerializerInterceptor } from './common/interceptors/decimal-serializer.interceptor'
 import { ConfigService } from '@nestjs/config'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
@@ -43,10 +43,7 @@ async function bootstrap() {
   app.enableCors({ origin: corsOrigin, credentials: true })
 
   app.useGlobalFilters(new GlobalExceptionFilter())
-  app.useGlobalInterceptors(
-    new DecimalSerializerInterceptor(),
-    new ClassSerializerInterceptor(app.get(Reflector)),
-  )
+  app.useGlobalInterceptors(new DecimalSerializerInterceptor())
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common'
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
+
+// Decimal.toJSON() returns a string by default ("1499.99"). Override to return a number so
+// JSON.stringify always produces a numeric JSON value instead of a string or internal {s,e,d} structure.
+;(Prisma.Decimal.prototype as unknown as { toJSON: () => number }).toJSON = function (this: Prisma.Decimal) {
+  return this.toNumber()
+}
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {

--- a/frontend/src/pages/Subscriptions.tsx
+++ b/frontend/src/pages/Subscriptions.tsx
@@ -58,7 +58,7 @@ export function SubscriptionsPage() {
     CANCELED:  allSubs.filter(s => s.status === 'CANCELED').length,
   }
 
-  const activeMrr = allSubs.filter(s => s.status === 'ACTIVE').reduce((s, x) => s + (x.plan?.priceMonthly ?? 0), 0)
+  const activeMrr = allSubs.filter(s => s.status === 'ACTIVE').reduce((s, x) => s + Number(x.plan?.priceMonthly ?? 0), 0)
 
   if (error) {
     return (


### PR DESCRIPTION
## Problema

O PR anterior (#106) não corrigiu o bug completamente — os valores de `priceMonthly` passaram a exibir `NaN` em vez de `[object Object]`.

**Causa raiz**: O `ClassSerializerInterceptor` (registrado antes do `DecimalSerializerInterceptor`) usa `class-transformer` internamente. Na pipeline de resposta NestJS, o interceptor registrado **segundo** é executado **primeiro** na resposta. O `class-transformer` enumerava os atributos próprios do Decimal (`s`, `e`, `d`) antes do `DecimalSerializerInterceptor` ter chance de detectar o `toNumber()`, resultando em `{"priceMonthly":{"s":1,"e":2,"d":[397]}}`.

No frontend, `Number({s:1,e:2,d:[397]})` = `NaN`, o que causava `NaN` nos preços e na soma de MRR da página de Assinaturas.

## Correção em três camadas

1. **Remove `ClassSerializerInterceptor` global** — não há DTOs com `@Exclude`/`@Transform` no projeto; o interceptor era um no-op que quebrava os Decimals
2. **Patch `Decimal.prototype.toJSON` no `PrismaService`** — garante que `JSON.stringify` produza um número JSON (`1499.99`) em vez de string ou estrutura interna, independente de interceptors
3. **`Number()` explícito no `reduce` de `activeMrr` em `Subscriptions.tsx`** — proteção defensiva no frontend para acumuladores aritméticos

Closes #104