### PR TITLE
feat(organizations): expor contagem de usuários do contrato via clinic-api

### DIFF
--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -75,8 +75,21 @@ export class OrganizationsController {
 
   @Get(':id')
   @Roles('SUPER_ADMIN', 'SUPPORT')
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
-    return this.repo.findById(id)
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    const org = await this.repo.findById(id)
+    if (!org) return null
+
+    let userCount: number | null = null
+    if (org.clinicExternalId) {
+      try {
+        const users = await this.clinicApi.listClinicUsers(org.clinicExternalId)
+        userCount = users.length
+      } catch {
+        // clinic-api unavailable — return null, don't break the page
+      }
+    }
+
+    return { ...org, userCount }
   }
 
   @Patch(':id')

--- a/frontend/src/pages/OrganizationDetail.tsx
+++ b/frontend/src/pages/OrganizationDetail.tsx
@@ -170,7 +170,7 @@ export function OrganizationDetailPage() {
       </div>
 
       {/* Stat strip */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', background: 'var(--surface)', border: '1px solid var(--ds-border)', borderRadius: 12, overflow: 'hidden' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${org.userCount != null ? 5 : 4}, 1fr)`, background: 'var(--surface)', border: '1px solid var(--ds-border)', borderRadius: 12, overflow: 'hidden' }}>
         {activeSubscription && (
           <div style={{ padding: '16px 20px', borderRight: '1px solid var(--divider)' }}>
             <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500, marginBottom: 6 }}>MRR contratado</div>
@@ -197,12 +197,24 @@ export function OrganizationDetailPage() {
             </div>
           </div>
         )}
-        <div style={{ padding: '16px 20px' }}>
+        <div style={{ padding: '16px 20px', borderRight: org.userCount != null ? '1px solid var(--divider)' : undefined }}>
           <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500, marginBottom: 6 }}>Cadastro</div>
           <div style={{ fontFamily: 'var(--font-display)', fontSize: 16, fontWeight: 600, color: 'var(--text)' }}>
             {formatDate(org.createdAt)}
           </div>
         </div>
+        {org.userCount != null && (
+          <div style={{ padding: '16px 20px' }}>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500, marginBottom: 6 }}>Usuários</div>
+            <div style={{ fontFamily: 'var(--font-display)', fontSize: 24, fontWeight: 600, letterSpacing: '-0.02em', color: 'var(--text)', fontVariantNumeric: 'tabular-nums' }}>
+              {org.userCount}
+              {activeSubscription?.plan?.maxUsers != null && (
+                <span style={{ fontSize: 14, color: 'var(--text-muted)', fontWeight: 500, marginLeft: 4 }}>/ {activeSubscription.plan.maxUsers}</span>
+              )}
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>Usuários ativos na clínica</div>
+          </div>
+        )}
       </div>
 
       {/* Two-col layout */}

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -22,6 +22,7 @@ export interface Organization {
   createdAt: string
   updatedAt: string
   mrr: number | null
+  userCount?: number | null
 }
 
 export interface Plan {


### PR DESCRIPTION
## Summary

- `GET /organizations/:id` agora inclui `userCount` (contagem de usuários ativos via `ClinicApiService.listClinicUsers`)
- Falha na clinic-api retorna `null` sem quebrar o endpoint (degradação graciosa)
- Frontend exibe tile **Usuários X / maxUsers** no stat strip quando o valor está disponível

## Test plan

- [ ] Org com `clinicExternalId` → tile exibe `userCount / maxUsers`
- [ ] Org sem `clinicExternalId` → tile não aparece
- [ ] Clinic-api indisponível → página carrega normalmente, tile não aparece
- [ ] `tsc --noEmit` sem erros ✅

Closes #101