### PR TITLE
feat(organizations): timeline de eventos do contrato

### DIFF
--- a/backend/prisma/migrations/20260514120000_add_org_events/migration.sql
+++ b/backend/prisma/migrations/20260514120000_add_org_events/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "OrgEventType" AS ENUM ('ORG_CREATED', 'STATUS_CHANGED', 'SUBSCRIPTION_STARTED', 'SUBSCRIPTION_CANCELED', 'PLAN_CHANGED', 'TRIAL_STARTED', 'TRIAL_CONVERTED', 'INVOICE_PAID', 'INVOICE_OVERDUE', 'USER_ADDED', 'USER_REMOVED', 'PASSWORD_RESET');
+
+-- CreateTable
+CREATE TABLE "org_events" (
+    "id" TEXT NOT NULL,
+    "organization_id" TEXT NOT NULL,
+    "type" "OrgEventType" NOT NULL,
+    "payload" JSONB,
+    "actor_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "org_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "org_events_organization_id_created_at_idx" ON "org_events"("organization_id", "created_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "org_events" ADD CONSTRAINT "org_events_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -80,6 +80,7 @@ model Organization {
   updatedAt  DateTime  @updatedAt @map("updated_at")
 
   subscriptions Subscription[]
+  events        OrgEvent[]
 
   @@index([status])
   @@index([clinicExternalId])
@@ -147,6 +148,39 @@ enum InvoiceStatus {
   PAID
   OVERDUE
   CANCELED
+}
+
+// ──────────────────────────────────────────────
+// OrgEvent — timeline de eventos do ciclo de vida de uma organização
+// ──────────────────────────────────────────────
+
+enum OrgEventType {
+  ORG_CREATED
+  STATUS_CHANGED
+  SUBSCRIPTION_STARTED
+  SUBSCRIPTION_CANCELED
+  PLAN_CHANGED
+  TRIAL_STARTED
+  TRIAL_CONVERTED
+  INVOICE_PAID
+  INVOICE_OVERDUE
+  USER_ADDED
+  USER_REMOVED
+  PASSWORD_RESET
+}
+
+model OrgEvent {
+  id             String       @id @default(uuid())
+  organizationId String       @map("organization_id")
+  type           OrgEventType
+  payload        Json?
+  actorId        String?      @map("actor_id")
+  createdAt      DateTime     @default(now()) @map("created_at")
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, createdAt(sort: Desc)])
+  @@map("org_events")
 }
 
 model Invoice {

--- a/backend/src/organizations/application/create-organization-with-owner.usecase.spec.ts
+++ b/backend/src/organizations/application/create-organization-with-owner.usecase.spec.ts
@@ -7,6 +7,7 @@ import { IOrganizationRepository } from '../domain/organization.repository'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
 import { PrismaService } from '../../prisma/prisma.service'
 import { ResolveTrialPlan } from './resolve-trial-plan'
+import { OrgEventService } from './org-event.service'
 import { Organization } from '../domain/organization.entity'
 
 const makeOrg = (overrides: Partial<Organization> = {}): Organization => ({
@@ -72,6 +73,7 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
   let clinicApi: jest.Mocked<ClinicApiService>
   let prisma: jest.Mocked<Pick<PrismaService, '$transaction' | 'plan'>>
   let resolveTrialPlan: jest.Mocked<ResolveTrialPlan>
+  let orgEvents: jest.Mocked<OrgEventService>
   let sut: CreateOrganizationWithOwnerUseCase
   let tx: ReturnType<typeof makeTx>
 
@@ -99,12 +101,14 @@ describe('CreateOrganizationWithOwnerUseCase', () => {
       plan: { findUniqueOrThrow: jest.fn().mockResolvedValue({ maxUsers: 5, maxPatients: 100 }) } as any,
     }
     resolveTrialPlan = { planId: jest.fn().mockResolvedValue('plan-trial-id') } as any
+    orgEvents = { record: jest.fn().mockResolvedValue(undefined), list: jest.fn() } as any
 
     sut = new CreateOrganizationWithOwnerUseCase(
       repo as any,
       clinicApi,
       prisma as any,
       resolveTrialPlan,
+      orgEvents,
     )
   })
 

--- a/backend/src/organizations/application/create-organization-with-owner.usecase.ts
+++ b/backend/src/organizations/application/create-organization-with-owner.usecase.ts
@@ -5,6 +5,7 @@ import { ClinicApiService } from '../../clinic-api/clinic-api.service'
 import { PrismaService } from '../../prisma/prisma.service'
 import { ResolveTrialPlan } from './resolve-trial-plan'
 import { generateProvisionalPassword } from './provisional-password'
+import { OrgEventService } from './org-event.service'
 
 export interface CreateOrganizationWithOwnerInput {
   organizationType: 'CLINIC_PJ' | 'SOLO_PF'
@@ -50,6 +51,7 @@ export class CreateOrganizationWithOwnerUseCase {
     private readonly clinicApi: ClinicApiService,
     private readonly prisma: PrismaService,
     private readonly resolveTrialPlan: ResolveTrialPlan,
+    private readonly orgEvents: OrgEventService,
   ) {}
 
   async execute(input: CreateOrganizationWithOwnerInput): Promise<CreateOrganizationWithOwnerResult> {
@@ -148,6 +150,16 @@ export class CreateOrganizationWithOwnerUseCase {
     await this.clinicApi.updateClinicAccess(clinic.clinicId, 'ACTIVE', {
       maxUsers: plan.maxUsers,
       maxPatients: plan.maxPatients,
+    })
+
+    await this.orgEvents.record(organization.id, 'ORG_CREATED', {
+      document,
+      documentType,
+      clinicId: clinic.clinicId,
+    })
+    await this.orgEvents.record(organization.id, 'TRIAL_STARTED', {
+      planId: trialPlanId,
+      trialEndsAt: trialEndsAt.toISOString(),
     })
 
     if (personResp.reused) {

--- a/backend/src/organizations/application/org-event.service.ts
+++ b/backend/src/organizations/application/org-event.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common'
+import { OrgEventType } from '@prisma/client'
+import { PrismaService } from '../../prisma/prisma.service'
+
+@Injectable()
+export class OrgEventService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async record(
+    organizationId: string,
+    type: OrgEventType,
+    payload?: Record<string, unknown>,
+    actorId?: string,
+  ): Promise<void> {
+    await this.prisma.orgEvent.create({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: { organizationId, type, payload: (payload as any) ?? undefined, actorId: actorId ?? null },
+    })
+  }
+
+  async list(organizationId: string, limit = 20) {
+    return this.prisma.orgEvent.findMany({
+      where: { organizationId },
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(limit, 100),
+    })
+  }
+}

--- a/backend/src/organizations/application/reset-clinic-user-password.usecase.spec.ts
+++ b/backend/src/organizations/application/reset-clinic-user-password.usecase.spec.ts
@@ -1,10 +1,12 @@
 import { ResetClinicUserPasswordUseCase } from './reset-clinic-user-password.usecase'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
 import { ResolveClinicId } from './resolve-clinic-id'
+import { OrgEventService } from './org-event.service'
 
 describe('ResetClinicUserPasswordUseCase', () => {
   let clinicApi: jest.Mocked<ClinicApiService>
   let resolveClinicId: jest.Mocked<ResolveClinicId>
+  let orgEvents: jest.Mocked<OrgEventService>
   let sut: ResetClinicUserPasswordUseCase
 
   beforeEach(() => {
@@ -14,7 +16,8 @@ describe('ResetClinicUserPasswordUseCase', () => {
     resolveClinicId = {
       byOrganizationId: jest.fn().mockResolvedValue('clinic-1'),
     } as any
-    sut = new ResetClinicUserPasswordUseCase(clinicApi, resolveClinicId)
+    orgEvents = { record: jest.fn().mockResolvedValue(undefined), list: jest.fn() } as any
+    sut = new ResetClinicUserPasswordUseCase(clinicApi, resolveClinicId, orgEvents)
   })
 
   it('resolves clinic ID from organization ID before calling the API', async () => {

--- a/backend/src/organizations/application/reset-clinic-user-password.usecase.ts
+++ b/backend/src/organizations/application/reset-clinic-user-password.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
 import { ResolveClinicId } from './resolve-clinic-id'
 import { generateProvisionalPassword } from './provisional-password'
+import { OrgEventService } from './org-event.service'
 
 export interface ResetClinicUserPasswordResult {
   organizationUserId: string
@@ -13,6 +14,7 @@ export class ResetClinicUserPasswordUseCase {
   constructor(
     private readonly clinicApi: ClinicApiService,
     private readonly resolveClinicId: ResolveClinicId,
+    private readonly orgEvents: OrgEventService,
   ) {}
 
   async execute(
@@ -24,6 +26,7 @@ export class ResetClinicUserPasswordUseCase {
     const provisionalPassword = generateProvisionalPassword()
     await this.clinicApi.resetClinicUserPassword(clinicId, organizationUserId, provisionalPassword)
 
+    await this.orgEvents.record(organizationId, 'PASSWORD_RESET', { organizationUserId })
     return { organizationUserId, provisionalPassword }
   }
 }

--- a/backend/src/organizations/application/update-status.usecase.spec.ts
+++ b/backend/src/organizations/application/update-status.usecase.spec.ts
@@ -2,6 +2,7 @@ import { NotFoundException } from '@nestjs/common'
 import { UpdateOrgStatusUseCase } from './update-status.usecase'
 import { IOrganizationRepository } from '../domain/organization.repository'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
+import { OrgEventService } from './org-event.service'
 import { Organization, OrgStatus } from '../domain/organization.entity'
 
 const makeOrg = (overrides: Partial<Organization> = {}): Organization => ({
@@ -49,7 +50,8 @@ describe('UpdateOrgStatusUseCase', () => {
       resetClinicUserPassword: jest.fn(),
     } as any
     prisma = makePrisma()
-    sut = new UpdateOrgStatusUseCase(repo as any, clinicApi, prisma as any)
+    const orgEvents = { record: jest.fn().mockResolvedValue(undefined), list: jest.fn() } as any
+    sut = new UpdateOrgStatusUseCase(repo as any, clinicApi, prisma as any, orgEvents)
   })
 
   it('throws NotFoundException when organization does not exist', async () => {
@@ -89,7 +91,8 @@ describe('UpdateOrgStatusUseCase', () => {
   it('passes plan limits from active subscription to updateClinicAccess', async () => {
     const sub = { plan: { maxUsers: 10, maxPatients: 500 } }
     prisma = makePrisma(sub)
-    sut = new UpdateOrgStatusUseCase(repo as any, clinicApi, prisma as any)
+    const orgEventsLocal = { record: jest.fn().mockResolvedValue(undefined), list: jest.fn() } as any
+    sut = new UpdateOrgStatusUseCase(repo as any, clinicApi, prisma as any, orgEventsLocal)
 
     repo.findById.mockResolvedValue(makeOrg())
     repo.update.mockResolvedValue(makeOrg())

--- a/backend/src/organizations/application/update-status.usecase.spec.ts
+++ b/backend/src/organizations/application/update-status.usecase.spec.ts
@@ -2,7 +2,6 @@ import { NotFoundException } from '@nestjs/common'
 import { UpdateOrgStatusUseCase } from './update-status.usecase'
 import { IOrganizationRepository } from '../domain/organization.repository'
 import { ClinicApiService } from '../../clinic-api/clinic-api.service'
-import { OrgEventService } from './org-event.service'
 import { Organization, OrgStatus } from '../domain/organization.entity'
 
 const makeOrg = (overrides: Partial<Organization> = {}): Organization => ({

--- a/backend/src/organizations/application/update-status.usecase.ts
+++ b/backend/src/organizations/application/update-status.usecase.ts
@@ -3,6 +3,7 @@ import { IOrganizationRepository, ORGANIZATION_REPOSITORY } from '../domain/orga
 import { Organization, OrgStatus } from '../domain/organization.entity'
 import { ClinicApiService, ClinicAccessStatus } from '../../clinic-api/clinic-api.service'
 import { PrismaService } from '../../prisma/prisma.service'
+import { OrgEventService } from './org-event.service'
 
 const orgStatusToClinicAccess: Record<OrgStatus, ClinicAccessStatus> = {
   ACTIVE: 'ACTIVE',
@@ -17,6 +18,7 @@ export class UpdateOrgStatusUseCase {
     private readonly repo: IOrganizationRepository,
     private readonly clinicApi: ClinicApiService,
     private readonly prisma: PrismaService,
+    private readonly orgEvents: OrgEventService,
   ) {}
 
   async execute(id: string, status: OrgStatus): Promise<Organization> {
@@ -40,6 +42,11 @@ export class UpdateOrgStatusUseCase {
       )
     }
 
-    return this.repo.update(id, { status })
+    const updated = await this.repo.update(id, { status })
+    await this.orgEvents.record(id, 'STATUS_CHANGED', {
+      from: org.status,
+      to: status,
+    })
+    return updated
   }
 }

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -15,6 +15,7 @@ import { UpdateOrgStatusUseCase } from './application/update-status.usecase'
 import { ListOrganizationsUseCase } from './application/list-organizations.usecase'
 import { ResetClinicUserPasswordUseCase } from './application/reset-clinic-user-password.usecase'
 import { ResolveClinicId } from './application/resolve-clinic-id'
+import { OrgEventService } from './application/org-event.service'
 import { CreateOrganizationDto } from './dto/create-organization.dto'
 import { CreateOrganizationWithOwnerDto } from './dto/create-organization-with-owner.dto'
 import { UpdateOrganizationDto, UpdateOrgStatusDto } from './dto/update-organization.dto'
@@ -36,6 +37,7 @@ export class OrganizationsController {
     private readonly resetClinicUserPassword: ResetClinicUserPasswordUseCase,
     private readonly resolveClinicId: ResolveClinicId,
     private readonly clinicApi: ClinicApiService,
+    private readonly orgEvents: OrgEventService,
     @Inject(ORGANIZATION_REPOSITORY)
     private readonly repo: IOrganizationRepository,
   ) {}
@@ -95,6 +97,18 @@ export class OrganizationsController {
   @Roles('SUPER_ADMIN')
   remove(@Param('id', ParseUUIDPipe) id: string) {
     return this.repo.delete(id)
+  }
+
+  // ─── Timeline de eventos ─────────────────────────────────────
+
+  @Get(':id/events')
+  @Roles('SUPER_ADMIN', 'SUPPORT')
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  listEvents(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('limit') limit?: number,
+  ) {
+    return this.orgEvents.list(id, Number(limit) || 20)
   }
 
   // ─── Usuários da clínica (via clinic-api) ───────────────────

--- a/backend/src/organizations/organizations.module.ts
+++ b/backend/src/organizations/organizations.module.ts
@@ -7,6 +7,7 @@ import { ListOrganizationsUseCase } from './application/list-organizations.useca
 import { ResetClinicUserPasswordUseCase } from './application/reset-clinic-user-password.usecase'
 import { ResolveClinicId } from './application/resolve-clinic-id'
 import { ResolveTrialPlan } from './application/resolve-trial-plan'
+import { OrgEventService } from './application/org-event.service'
 import { PrismaOrganizationRepository } from './infra/prisma-organization.repository'
 import { ORGANIZATION_REPOSITORY } from './domain/organization.repository'
 
@@ -20,6 +21,7 @@ import { ORGANIZATION_REPOSITORY } from './domain/organization.repository'
     ResetClinicUserPasswordUseCase,
     ResolveClinicId,
     ResolveTrialPlan,
+    OrgEventService,
     {
       provide: ORGANIZATION_REPOSITORY,
       useClass: PrismaOrganizationRepository,

--- a/frontend/src/components/organizations/OrgTimeline.tsx
+++ b/frontend/src/components/organizations/OrgTimeline.tsx
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+import type { OrgEvent, OrgEventType } from '@/types/admin'
+import { Card, CardHeader } from '@/components/ui/ds'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const EVENT_META: Record<OrgEventType, { label: string; color: string }> = {
+  ORG_CREATED:           { label: 'Organização criada',          color: 'var(--ok-ink)' },
+  STATUS_CHANGED:        { label: 'Status alterado',             color: 'var(--warn-ink)' },
+  SUBSCRIPTION_STARTED:  { label: 'Assinatura iniciada',         color: 'var(--ok-ink)' },
+  SUBSCRIPTION_CANCELED: { label: 'Assinatura cancelada',        color: 'var(--danger-ink, #e03)' },
+  PLAN_CHANGED:          { label: 'Plano alterado',              color: 'var(--p)' },
+  TRIAL_STARTED:         { label: 'Trial iniciado',              color: 'var(--p)' },
+  TRIAL_CONVERTED:       { label: 'Trial convertido',            color: 'var(--ok-ink)' },
+  INVOICE_PAID:          { label: 'Fatura paga',                 color: 'var(--ok-ink)' },
+  INVOICE_OVERDUE:       { label: 'Fatura vencida',              color: 'var(--danger-ink, #e03)' },
+  USER_ADDED:            { label: 'Usuário adicionado',          color: 'var(--text-muted)' },
+  USER_REMOVED:          { label: 'Usuário removido',            color: 'var(--text-muted)' },
+  PASSWORD_RESET:        { label: 'Senha redefinida',            color: 'var(--text-muted)' },
+}
+
+function eventDetail(event: OrgEvent): string | null {
+  const p = event.payload
+  if (!p) return null
+  if (event.type === 'STATUS_CHANGED' && p.from && p.to) return `${p.from} → ${p.to}`
+  if (event.type === 'TRIAL_STARTED' && p.trialEndsAt) return `até ${formatDate(p.trialEndsAt as string)}`
+  return null
+}
+
+interface Props {
+  organizationId: string
+}
+
+export function OrgTimeline({ organizationId }: Props) {
+  const { data: events, isLoading, isError } = useQuery<OrgEvent[]>({
+    queryKey: ['org-events', organizationId],
+    queryFn: () => api.get(`/organizations/${organizationId}/events`, { params: { limit: 30 } }).then((r) => r.data),
+  })
+
+  return (
+    <Card>
+      <CardHeader title="Histórico de eventos" />
+      <div style={{ padding: '4px 18px 18px' }}>
+        {isLoading && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {[1, 2, 3].map((i) => <Skeleton key={i} className="h-8 w-full rounded" />)}
+          </div>
+        )}
+        {isError && (
+          <p style={{ fontSize: 13, color: 'var(--danger-ink, #e03)', margin: 0 }}>
+            Falha ao carregar eventos.
+          </p>
+        )}
+        {events && events.length === 0 && (
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>Nenhum evento registrado.</p>
+        )}
+        {events && events.length > 0 && (
+          <div style={{ position: 'relative' }}>
+            <div style={{ position: 'absolute', left: 7, top: 8, bottom: 8, width: 1, background: 'var(--divider)' }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+              {events.map((ev) => {
+                const meta = EVENT_META[ev.type]
+                const detail = eventDetail(ev)
+                return (
+                  <div key={ev.id} style={{ display: 'flex', gap: 16, paddingBottom: 14, position: 'relative' }}>
+                    <div style={{ width: 15, height: 15, borderRadius: '50%', background: meta.color, border: '2px solid var(--surface)', flexShrink: 0, marginTop: 1, zIndex: 1 }} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text)', lineHeight: '18px' }}>
+                        {meta.label}
+                        {detail && <span style={{ fontWeight: 400, color: 'var(--text-muted)', marginLeft: 6 }}>{detail}</span>}
+                      </div>
+                      <div style={{ fontSize: 11.5, color: 'var(--text-muted)', marginTop: 2, fontFamily: 'var(--font-mono)' }}>
+                        {formatDate(ev.createdAt)}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/pages/OrganizationDetail.tsx
+++ b/frontend/src/pages/OrganizationDetail.tsx
@@ -6,6 +6,7 @@ import type { Organization, OrgStatus, Subscription, Invoice } from '@/types/adm
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/contexts/ToastContext'
 import { ClinicUsersSection } from '@/components/organizations/ClinicUsersSection'
+import { OrgTimeline } from '@/components/organizations/OrgTimeline'
 import { OrgAvatar, StatusPill, PlanBadge, Card, CardHeader } from '@/components/ui/ds'
 
 const BackIcon = () => (
@@ -232,8 +233,9 @@ export function OrganizationDetailPage() {
           {org.clinicExternalId && <ClinicUsersSection organizationId={org.id} />}
         </div>
 
-        {/* Right: invoice history as timeline stand-in */}
+        {/* Right: timeline + invoice history */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <OrgTimeline organizationId={org.id} />
           {invoices && invoices.length > 0 && (
             <Card>
               <CardHeader

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -97,3 +97,26 @@ export interface PaginatedResponse<T> {
   data: T[]
   total: number
 }
+
+export type OrgEventType =
+  | 'ORG_CREATED'
+  | 'STATUS_CHANGED'
+  | 'SUBSCRIPTION_STARTED'
+  | 'SUBSCRIPTION_CANCELED'
+  | 'PLAN_CHANGED'
+  | 'TRIAL_STARTED'
+  | 'TRIAL_CONVERTED'
+  | 'INVOICE_PAID'
+  | 'INVOICE_OVERDUE'
+  | 'USER_ADDED'
+  | 'USER_REMOVED'
+  | 'PASSWORD_RESET'
+
+export interface OrgEvent {
+  id: string
+  organizationId: string
+  type: OrgEventType
+  payload: Record<string, unknown> | null
+  actorId: string | null
+  createdAt: string
+}


### PR DESCRIPTION
## Summary

- Novo modelo Prisma `OrgEvent` + enum `OrgEventType` (12 tipos) com migration manual
- `OrgEventService` centraliza registro e listagem de eventos
- Eventos registrados automaticamente:
  - `CreateOrganizationWithOwnerUseCase` → `ORG_CREATED`, `TRIAL_STARTED`
  - `UpdateOrgStatusUseCase` → `STATUS_CHANGED` (com payload `from`/`to`)
  - `ResetClinicUserPasswordUseCase` → `PASSWORD_RESET`
- `GET /api/admin/organizations/:id/events?limit=20` paginado, protegido por `JwtAuthGuard`
- Frontend: componente `OrgTimeline` com timeline vertical substituindo o placeholder; histórico de faturas permanece como card separado

## Test plan

- [ ] Migration aplicada no deploy (`prisma migrate deploy`)
- [ ] Criar org → eventos `ORG_CREATED` + `TRIAL_STARTED` aparecem na timeline
- [ ] Alterar status → evento `STATUS_CHANGED` com payload `from`/`to`
- [ ] Resetar senha → evento `PASSWORD_RESET`
- [ ] Timeline exibe eventos ordenados por data DESC
- [ ] Org sem eventos → mensagem "Nenhum evento registrado"
- [ ] `tsc --noEmit` sem erros ✅

Closes #102