### PR TITLE
feat(clinic-ext): plan change and subscription cancellation endpoints

### DIFF
--- a/backend/src/clinic-ext/clinic-ext.controller.ts
+++ b/backend/src/clinic-ext/clinic-ext.controller.ts
@@ -1,7 +1,17 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common'
+import { Body, Controller, Get, Patch, Post, Query, UseGuards } from '@nestjs/common'
 import { ApiTags, ApiHeader, ApiQuery } from '@nestjs/swagger'
+import { IsString, IsUUID } from 'class-validator'
 import { ClinicExternalApiKeyGuard } from '../common/guards/clinic-external-api-key.guard'
 import { ClinicExtService } from './clinic-ext.service'
+
+class ChangePlanDto {
+  @IsString() clinicId: string
+  @IsUUID() planId: string
+}
+
+class CancelSubscriptionDto {
+  @IsString() clinicId: string
+}
 
 @ApiTags('clinic-ext')
 @ApiHeader({ name: 'x-clinic-api-key', required: true })
@@ -19,5 +29,15 @@ export class ClinicExtController {
   @Get('plans')
   getPlans() {
     return this.service.getPlans()
+  }
+
+  @Patch('subscription/plan')
+  changePlan(@Body() dto: ChangePlanDto) {
+    return this.service.changePlan(dto.clinicId, dto.planId)
+  }
+
+  @Post('subscription/cancel')
+  cancelSubscription(@Body() dto: CancelSubscriptionDto) {
+    return this.service.cancelSubscription(dto.clinicId)
   }
 }

--- a/backend/src/clinic-ext/clinic-ext.service.ts
+++ b/backend/src/clinic-ext/clinic-ext.service.ts
@@ -1,9 +1,13 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
+import { ClinicApiService } from '../clinic-api/clinic-api.service'
 
 @Injectable()
 export class ClinicExtService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clinicApi: ClinicApiService,
+  ) {}
 
   async getSubscription(clinicId: string) {
     const org = await this.prisma.organization.findFirst({
@@ -57,5 +61,74 @@ export class ClinicExtService {
         features: true,
       },
     })
+  }
+
+  async changePlan(clinicId: string, planId: string) {
+    const org = await this.prisma.organization.findFirst({
+      where: { clinicExternalId: clinicId },
+      include: {
+        subscriptions: {
+          where: { status: { in: ['TRIAL', 'ACTIVE'] } },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+      },
+    })
+
+    if (!org) throw new NotFoundException('Organização não encontrada')
+
+    const current = org.subscriptions[0]
+    if (!current) throw new BadRequestException('Nenhuma assinatura ativa encontrada')
+    if (current.planId === planId) throw new BadRequestException('Plano já é o plano atual')
+
+    const newPlan = await this.prisma.plan.findUnique({ where: { id: planId } })
+    if (!newPlan || !newPlan.isActive) throw new NotFoundException('Plano não encontrado')
+
+    await this.prisma.subscription.update({
+      where: { id: current.id },
+      data: {
+        planId,
+        status: 'ACTIVE',
+        trialEndsAt: null,
+        startDate: new Date(),
+        endDate: null,
+      },
+    })
+
+    await this.clinicApi.updateClinicAccess(clinicId, 'ACTIVE', {
+      maxUsers: newPlan.maxUsers,
+      maxPatients: newPlan.maxPatients,
+    })
+
+    return { ok: true, planId, planName: newPlan.name }
+  }
+
+  async cancelSubscription(clinicId: string) {
+    const org = await this.prisma.organization.findFirst({
+      where: { clinicExternalId: clinicId },
+      include: {
+        subscriptions: {
+          where: { status: { in: ['TRIAL', 'ACTIVE'] } },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+      },
+    })
+
+    if (!org) throw new NotFoundException('Organização não encontrada')
+
+    const current = org.subscriptions[0]
+    if (!current) throw new BadRequestException('Nenhuma assinatura ativa encontrada')
+
+    // Grace period of 30 days before access should be reviewed
+    const endDate = new Date()
+    endDate.setDate(endDate.getDate() + 30)
+
+    await this.prisma.subscription.update({
+      where: { id: current.id },
+      data: { status: 'CANCELED', endDate },
+    })
+
+    return { ok: true, endDate }
   }
 }


### PR DESCRIPTION
## Summary

Adiciona dois endpoints de escrita no canal `clinic→admin` (`clinic-ext`) para suportar a gestão de assinatura self-service da issue pelvi-ui#27:

- `PATCH /api/clinic-ext/subscription/plan { clinicId, planId }` — altera o plano da assinatura ativa/trial:
  - Valida que o novo plano existe e está ativo
  - Atualiza `planId`, `status = ACTIVE`, `trialEndsAt = null`, `startDate = now`, `endDate = null`
  - Propaga novos limites ao pelvi-ui via `clinicApi.updateClinicAccess(clinicId, 'ACTIVE', { maxUsers, maxPatients })`

- `POST /api/clinic-ext/subscription/cancel { clinicId }` — cancela a assinatura:
  - Define `status = CANCELED` e `endDate = now + 30 dias` (período de graça)
  - Não bloqueia acesso imediatamente

Ambos os endpoints usam `ClinicExternalApiKeyGuard` (`x-clinic-api-key`) e validação com DTOs class-validator.

## Test plan

- [ ] `PATCH /api/clinic-ext/subscription/plan` com planId válido → 200, limites atualizados no pelvi-ui
- [ ] `PATCH /api/clinic-ext/subscription/plan` com planId inválido → 404
- [ ] `PATCH /api/clinic-ext/subscription/plan` com mesmo plano → 400
- [ ] `POST /api/clinic-ext/subscription/cancel` → 200, `status = CANCELED`, `endDate = ~30d`
- [ ] Sem header `x-clinic-api-key` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)