### PR TITLE
fix(auth): add MaxLength to LoginDto to prevent bcrypt DoS

### DIFF
--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,12 +1,14 @@
-import { IsEmail, IsString } from 'class-validator'
+import { IsEmail, IsString, MaxLength } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 
 export class LoginDto {
   @ApiProperty({ description: 'User email address', example: 'user@example.com' })
   @IsEmail()
+  @MaxLength(254)
   email: string
 
   @ApiProperty({ description: 'User account password', example: 'P@ssw0rd123!' })
   @IsString()
+  @MaxLength(128)
   password: string
 }


### PR DESCRIPTION
## Summary

- `password` field capped at 128 characters before reaching bcrypt
- `email` field capped at 254 characters (RFC 5321 limit)
- Validation fails at the DTO layer, before any crypto work is done

## Context

Without an upper bound, an attacker could send a multi-megabyte payload in the password field. Even with the existing 5 req/min rate limit on `/login`, bcrypt processing of huge strings would block the event loop. This patch closes that gap.

## Test plan

- [ ] Send `POST /api/admin/auth/login` with `password` > 128 chars → expect `400 Bad Request`
- [ ] Send with `email` > 254 chars → expect `400 Bad Request`
- [ ] Normal login still works