### PR TITLE
fix(prisma): configure pg type parsers to serialize DateTime as ISO strings

### DIFF
--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -1,12 +1,18 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common'
 import { PrismaClient, Prisma } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
+import { types } from 'pg'
 
 // Decimal.toJSON() returns a string by default ("1499.99"). Override to return a number so
 // JSON.stringify always produces a numeric JSON value instead of a string or internal {s,e,d} structure.
 ;(Prisma.Decimal.prototype as unknown as { toJSON: () => number }).toJSON = function (this: Prisma.Decimal) {
   return this.toNumber()
 }
+
+// PrismaPg returns DateTime fields as Date objects that serialize as {} in JSON.
+// Configuring pg type parsers to return ISO strings fixes serialization for all DateTime fields.
+types.setTypeParser(types.builtins.TIMESTAMP, (val: string) => new Date(val).toISOString())
+types.setTypeParser(types.builtins.TIMESTAMPTZ, (val: string) => new Date(val).toISOString())
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {


### PR DESCRIPTION
## Summary

- `PrismaPg` retorna campos `DateTime` como objetos `Date` do JavaScript que o `JSON.stringify` serializa como `{}` em vez de strings ISO
- Resultado: campos `createdAt` e `updatedAt` chegam como `{}` no frontend, causando tela branca ao renderizar organizations
- Configurados os type parsers do `pg` para retornar ISO strings diretamente para tipos `timestamp` e `timestamptz`
- Fix análogo ao que já existe para `Decimal.toJSON()` neste mesmo arquivo

## Test plan

- [ ] Criar organização no admin → página de listagem carrega sem tela branca
- [ ] `createdAt` e `updatedAt` aparecem como strings ISO nas respostas da API (ex: `"2026-05-18T22:30:00.000Z"`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)