### PR TITLE
fix(interceptor): preserve Date objects in DecimalSerializerInterceptor

### DIFF
--- a/backend/src/common/interceptors/decimal-serializer.interceptor.ts
+++ b/backend/src/common/interceptors/decimal-serializer.interceptor.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators'
 
 function coerceDecimals(value: unknown): unknown {
   if (value === null || value === undefined) return value
+  if (value instanceof Date) return value
   // Prisma Decimal (decimal.js) exposes toNumber()
   if (typeof value === 'object' && typeof (value as { toNumber?: unknown }).toNumber === 'function') {
     return (value as { toNumber: () => number }).toNumber()


### PR DESCRIPTION
Object.entries(new Date()) returns [] because Date has no enumerable own properties, causing the generic object branch to produce {} for all DateTime fields. Adding an instanceof Date guard before the generic object check preserves dates for correct JSON serialization.