### PR TITLE
feat: plan visibility control and admin plan assignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,18 +18,18 @@ All development MUST follow this process — no exceptions:
 - Create a dedicated branch for each issue before writing any code
 - Branch naming convention: `<type>/<issue-number>-<short-slug>`
   - Examples: `fix/1-rate-limiting`, `feat/9-refresh-token`, `chore/14-db-indexes`
-- Always branch off `staging`:
+- Always branch off `main` (only production environment exists currently):
   ```bash
-  git checkout staging && git pull && git checkout -b fix/1-rate-limiting
+  git checkout main && git pull && git checkout -b fix/1-rate-limiting
   ```
 
 ### 3. Pull Request linked to the issue
-- Open a PR targeting `staging` with the issue number in the body using `Closes #<n>`
+- Open a PR targeting `main` with the issue number in the body using `Closes #<n>`
 - PR title should match the issue title (without the emoji prefix)
 - PR must pass TypeScript check (`tsc --noEmit`) before being considered ready
-- Use `gh pr create --base staging` and include the issue reference:
+- Use `gh pr create --base main` and include the issue reference:
   ```bash
-  gh pr create --base staging --title "..." --body "Closes #<n>"
+  gh pr create --base main --title "..." --body "Closes #<n>"
   ```
 
 ### 4. Update the board after merge
@@ -106,24 +106,24 @@ Copy `backend/.env.example` to `backend/.env.dev` and populate:
 | `CLINIC_INTERNAL_API_KEY` | Shared secret for admin→clinic calls (`x-internal-api-key` header). Must match `INTERNAL_API_KEY` on the clinic side. Rotation policy: every 90 days or immediately on suspected compromise. |
 | `CLINIC_EXTERNAL_API_KEY` | Shared secret for clinic→admin calls accepted on `x-clinic-api-key` header. Must match `ADMIN_EXTERNAL_API_KEY` in pelvi-ui. Same rotation policy. |
 | `SEED_ADMIN_EMAIL` | Email do super admin criado no seed (default: `admin@soupelvi.com.br`) |
-| `SEED_ADMIN_PASSWORD` | **Obrigatória.** Senha do super admin criado no seed. Sem essa var o seed falha. Deve estar definida tanto em `.env.dev` (local) quanto nas envs do Railway (staging/production). Se o admin já existir no banco, o seed pula a criação e mantém a senha atual. |
+| `SEED_ADMIN_PASSWORD` | **Obrigatória.** Senha do super admin criado no seed. Sem essa var o seed falha. Deve estar definida tanto em `.env.dev` (local) quanto nas envs do Coolify (production). Se o admin já existir no banco, o seed pula a criação e mantém a senha atual. |
 
 ### Docker
 
-Both frontend and backend have a `Dockerfile`. The backend uses `docker-entrypoint.sh`, which runs `prisma migrate deploy` + seed on startup (idempotent; set `RUN_SEED=false` to skip seeding). Both containers install via Bun. End-to-end orchestration with the clinic product lives in the parent `docker-compose.yml`.
+Both frontend and backend have a `Dockerfile`. The backend uses `docker-entrypoint.sh`, which runs `prisma migrate deploy` on startup, then seed if `RUN_SEED=true`. Both containers install via Bun. End-to-end orchestration with the clinic product lives in the parent `docker-compose.yml`.
 
-### Environments (Railway)
+**Production (Coolify)**: `RUN_SEED=false` — seed was used to bootstrap the super admin; production DB is already initialized. Migrations still run on every deploy.
 
-Railway and Git branches are aligned 1:1:
+### Environments (Coolify — VPS)
 
-| Git branch | Railway environment | Purpose |
-|------------|---------------------|---------|
-| `staging`  | `staging` (`stg`)   | Homologation — all PRs land here first |
-| `main`     | `production`        | Live traffic — promoted from `staging` after validation |
+Deployed on a VPS via **Coolify**. Currently **only production** is active — no staging environment yet.
 
-Database and infra (Railway services, env vars) follow the same split: each environment has its own isolated DB and configuration. Never point a staging service at the production database or vice versa.
+| Git branch | Coolify service | Purpose |
+|------------|-----------------|---------|
+| `main`     | `backoffice` (frontend) + `backoffice-api` (backend) | Live traffic |
 
-pelvi-ui mirrors this layout with identical `staging` and `production` environments on Railway so both services can be tested together end-to-end before promotion.
+- **Database**: Neon (PostgreSQL) — production only.
+- All PRs merge directly into `main`.
 
 ---
 

--- a/backend/prisma/migrations/20260519120000_add_plan_visible_to_clinic/migration.sql
+++ b/backend/prisma/migrations/20260519120000_add_plan_visible_to_clinic/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "plans" ADD COLUMN "visible_to_clinic" BOOLEAN NOT NULL DEFAULT true;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -97,9 +97,10 @@ model Plan {
   priceMonthly Decimal  @db.Decimal(10, 2) @map("price_monthly")
   maxUsers     Int      @map("max_users")
   maxPatients  Int      @map("max_patients")
-  features     Json? // ex: { nfse: true, whatsapp: false }
-  isActive     Boolean  @default(true) @map("is_active")
-  createdAt    DateTime @default(now()) @map("created_at")
+  features        Json? // ex: { nfse: true, whatsapp: false }
+  isActive        Boolean  @default(true) @map("is_active")
+  visibleToClinic Boolean  @default(true) @map("visible_to_clinic")
+  createdAt       DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 
   subscriptions Subscription[]

--- a/backend/src/clinic-ext/clinic-ext.service.ts
+++ b/backend/src/clinic-ext/clinic-ext.service.ts
@@ -50,7 +50,7 @@ export class ClinicExtService {
 
   getPlans() {
     return this.prisma.plan.findMany({
-      where: { isActive: true },
+      where: { isActive: true, visibleToClinic: true },
       orderBy: { priceMonthly: 'asc' },
       select: {
         id: true,

--- a/backend/src/organizations/application/change-plan-admin.usecase.ts
+++ b/backend/src/organizations/application/change-plan-admin.usecase.ts
@@ -1,0 +1,55 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common'
+import { PrismaService } from '../../prisma/prisma.service'
+import { ClinicApiService } from '../../clinic-api/clinic-api.service'
+import { OrgEventService } from './org-event.service'
+
+@Injectable()
+export class ChangePlanAdminUseCase {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clinicApi: ClinicApiService,
+    private readonly orgEvents: OrgEventService,
+  ) {}
+
+  async execute(organizationId: string, planId: string) {
+    const org = await this.prisma.organization.findUnique({
+      where: { id: organizationId },
+      include: {
+        subscriptions: {
+          where: { status: { in: ['TRIAL', 'ACTIVE'] } },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+      },
+    })
+
+    if (!org) throw new NotFoundException('Organização não encontrada')
+
+    const current = org.subscriptions[0]
+    if (!current) throw new BadRequestException('Nenhuma assinatura ativa encontrada')
+    if (current.planId === planId) throw new BadRequestException('Plano já é o plano atual')
+
+    const newPlan = await this.prisma.plan.findUnique({ where: { id: planId } })
+    if (!newPlan || !newPlan.isActive) throw new NotFoundException('Plano não encontrado ou inativo')
+
+    await this.prisma.subscription.update({
+      where: { id: current.id },
+      data: { planId, status: 'ACTIVE', trialEndsAt: null, startDate: new Date(), endDate: null },
+    })
+
+    if (org.clinicExternalId) {
+      await this.clinicApi.updateClinicAccess(org.clinicExternalId, 'ACTIVE', {
+        maxUsers: newPlan.maxUsers,
+        maxPatients: newPlan.maxPatients,
+      })
+    }
+
+    await this.orgEvents.record(organizationId, 'PLAN_CHANGED', {
+      from: current.planId,
+      to: planId,
+      planName: newPlan.name,
+    })
+
+    return { ok: true, planId, planName: newPlan.name }
+  }
+}

--- a/backend/src/organizations/dto/change-org-plan.dto.ts
+++ b/backend/src/organizations/dto/change-org-plan.dto.ts
@@ -1,0 +1,8 @@
+import { IsUUID } from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+
+export class ChangeOrgPlanDto {
+  @ApiProperty()
+  @IsUUID('4')
+  planId: string
+}

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller, Get, Post, Patch, Delete,
   Body, Param, ParseUUIDPipe, Query, UseGuards, NotFoundException,
+  HttpCode, HttpStatus,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger'
 import { Throttle } from '@nestjs/throttler'
@@ -14,6 +15,7 @@ import { CreateOrganizationWithOwnerUseCase } from './application/create-organiz
 import { UpdateOrgStatusUseCase } from './application/update-status.usecase'
 import { ListOrganizationsUseCase } from './application/list-organizations.usecase'
 import { ResetClinicUserPasswordUseCase } from './application/reset-clinic-user-password.usecase'
+import { ChangePlanAdminUseCase } from './application/change-plan-admin.usecase'
 import { ResolveClinicId } from './application/resolve-clinic-id'
 import { OrgEventService } from './application/org-event.service'
 import { CreateOrganizationDto } from './dto/create-organization.dto'
@@ -21,6 +23,7 @@ import { CreateOrganizationInputDto } from './dto/create-organization-input.dto'
 import { OrganizationType } from './dto/create-organization-with-owner.dto'
 import { UpdateOrganizationDto } from './dto/update-organization.dto'
 import { UpdateClinicUserDto } from './dto/update-clinic-user.dto'
+import { ChangeOrgPlanDto } from './dto/change-org-plan.dto'
 import { Inject } from '@nestjs/common'
 import { IOrganizationRepository, ORGANIZATION_REPOSITORY } from './domain/organization.repository'
 import { ClinicApiService } from '../clinic-api/clinic-api.service'
@@ -36,6 +39,7 @@ export class OrganizationsController {
     private readonly updateOrgStatus: UpdateOrgStatusUseCase,
     private readonly listOrgs: ListOrganizationsUseCase,
     private readonly resetClinicUserPassword: ResetClinicUserPasswordUseCase,
+    private readonly changePlanAdmin: ChangePlanAdminUseCase,
     private readonly resolveClinicId: ResolveClinicId,
     private readonly clinicApi: ClinicApiService,
     private readonly orgEvents: OrgEventService,
@@ -112,6 +116,18 @@ export class OrganizationsController {
   @Roles('SUPER_ADMIN')
   remove(@Param('id', ParseUUIDPipe) id: string) {
     return this.repo.delete(id)
+  }
+
+  // ─── Gerenciamento de assinatura (admin) ────────────────────
+
+  @Patch(':id/subscription/plan')
+  @Roles('SUPER_ADMIN')
+  @HttpCode(HttpStatus.OK)
+  changePlan(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ChangeOrgPlanDto,
+  ) {
+    return this.changePlanAdmin.execute(id, dto.planId)
   }
 
   // ─── Timeline de eventos ─────────────────────────────────────

--- a/backend/src/organizations/organizations.module.ts
+++ b/backend/src/organizations/organizations.module.ts
@@ -5,6 +5,7 @@ import { CreateOrganizationWithOwnerUseCase } from './application/create-organiz
 import { UpdateOrgStatusUseCase } from './application/update-status.usecase'
 import { ListOrganizationsUseCase } from './application/list-organizations.usecase'
 import { ResetClinicUserPasswordUseCase } from './application/reset-clinic-user-password.usecase'
+import { ChangePlanAdminUseCase } from './application/change-plan-admin.usecase'
 import { ResolveClinicId } from './application/resolve-clinic-id'
 import { ResolveTrialPlan } from './application/resolve-trial-plan'
 import { OrgEventService } from './application/org-event.service'
@@ -19,6 +20,7 @@ import { ORGANIZATION_REPOSITORY } from './domain/organization.repository'
     UpdateOrgStatusUseCase,
     ListOrganizationsUseCase,
     ResetClinicUserPasswordUseCase,
+    ChangePlanAdminUseCase,
     ResolveClinicId,
     ResolveTrialPlan,
     OrgEventService,

--- a/backend/src/plans/dto/create-plan.dto.ts
+++ b/backend/src/plans/dto/create-plan.dto.ts
@@ -34,4 +34,9 @@ export class CreatePlanDto {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean
+
+  @ApiPropertyOptional({ default: true, description: 'Se false, o plano não aparece na interface da clínica (somente via admin)' })
+  @IsOptional()
+  @IsBoolean()
+  visibleToClinic?: boolean
 }

--- a/frontend/src/components/plans/PlanFormModal.tsx
+++ b/frontend/src/components/plans/PlanFormModal.tsx
@@ -26,6 +26,7 @@ const schema = z.object({
   maxUsers: z.coerce.number().int().min(1, 'Mínimo 1 usuário'),
   maxPatients: z.coerce.number().int().min(1, 'Mínimo 1 paciente'),
   isActive: z.boolean(),
+  visibleToClinic: z.boolean(),
 })
 
 type FormData = z.infer<typeof schema>
@@ -49,8 +50,8 @@ export function PlanFormModal({ plan }: Props) {
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: plan
-      ? { name: plan.name, priceMonthly: plan.priceMonthly, maxUsers: plan.maxUsers, maxPatients: plan.maxPatients, isActive: plan.isActive }
-      : { isActive: true },
+      ? { name: plan.name, priceMonthly: plan.priceMonthly, maxUsers: plan.maxUsers, maxPatients: plan.maxPatients, isActive: plan.isActive, visibleToClinic: plan.visibleToClinic }
+      : { isActive: true, visibleToClinic: true },
   })
 
   useEffect(() => {
@@ -134,10 +135,17 @@ export function PlanFormModal({ plan }: Props) {
             </div>
           </div>
 
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
-            <input type="checkbox" {...register('isActive')} className="rounded border-input" />
-            Plano ativo
-          </label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" {...register('isActive')} className="rounded border-input" />
+              Plano ativo
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" {...register('visibleToClinic')} className="rounded border-input" />
+              <span>Visível na interface da clínica</span>
+              <span style={{ fontSize: 11.5, color: 'var(--text-muted)', marginLeft: 2 }}>(desmarcar = somente via admin)</span>
+            </label>
+          </div>
 
           <div className="flex justify-end gap-2 pt-2">
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>

--- a/frontend/src/pages/OrganizationDetail.tsx
+++ b/frontend/src/pages/OrganizationDetail.tsx
@@ -1,8 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams, Link } from 'react-router-dom'
+import { useState } from 'react'
 import { api } from '@/lib/api'
 import { formatDate, formatCNPJ, formatCurrency, getErrorMessage } from '@/lib/utils'
-import type { Organization, OrgStatus, Subscription, Invoice } from '@/types/admin'
+import type { Organization, OrgStatus, Subscription, Invoice, Plan } from '@/types/admin'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/contexts/ToastContext'
 import { ClinicUsersSection } from '@/components/organizations/ClinicUsersSection'
@@ -50,6 +51,115 @@ const statusLabel: Record<OrgStatus, { label: string; className: string }> = {
   ACTIVE:    { label: 'Ativa',     className: 'ok' },
   SUSPENDED: { label: 'Suspensa',  className: 'warn' },
   CANCELED:  { label: 'Cancelada', className: 'muted' },
+}
+
+function SubscriptionCard({ organizationId, subscription }: { organizationId: string; subscription: Subscription }) {
+  const [selectedPlanId, setSelectedPlanId] = useState(subscription.planId)
+  const [changing, setChanging] = useState(false)
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const { data: plans } = useQuery<Plan[]>({
+    queryKey: ['plans'],
+    queryFn: () => api.get('/plans').then((r) => r.data),
+  })
+
+  const changePlan = useMutation({
+    mutationFn: (planId: string) =>
+      api.patch(`/organizations/${organizationId}/subscription/plan`, { planId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['subscriptions', organizationId] })
+      queryClient.invalidateQueries({ queryKey: ['organization', organizationId] })
+      toast.success('Plano alterado com sucesso')
+      setChanging(false)
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  })
+
+  const activePlans = plans?.filter((p) => p.isActive) ?? []
+  const dirty = selectedPlanId !== subscription.planId
+
+  return (
+    <Card>
+      <CardHeader
+        title="Assinatura atual"
+        actions={
+          <button
+            onClick={() => setChanging((v) => !v)}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 6, height: 28, padding: '0 10px', borderRadius: 6, border: '1px solid transparent', background: 'transparent', fontSize: 12.5, fontWeight: 500, cursor: 'pointer', color: 'var(--p)', fontFamily: 'var(--font-sans)' }}
+          >
+            {changing ? 'Cancelar' : 'Alterar plano'}
+          </button>
+        }
+      />
+      <div style={{ padding: 18, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        <FieldItem label="Plano" value={subscription.plan?.name ?? '—'} />
+        <FieldItem label="Valor" value={subscription.plan ? `${formatCurrency(subscription.plan.priceMonthly)}/mês` : '—'} mono />
+        <FieldItem label="Início" value={formatDate(subscription.startDate)} mono />
+        <FieldItem label="Status" value={subscription.status} />
+      </div>
+      {changing && (
+        <div style={{ padding: '0 18px 18px', borderTop: '1px solid var(--divider)', paddingTop: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 500 }}>Selecionar novo plano</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {activePlans.map((plan) => (
+              <label
+                key={plan.id}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', borderRadius: 8,
+                  border: `1px solid ${selectedPlanId === plan.id ? 'var(--p-border)' : 'var(--ds-border)'}`,
+                  background: selectedPlanId === plan.id ? 'hsl(16 65% 44% / 0.05)' : 'var(--surface)',
+                  cursor: 'pointer', transition: 'border-color 0.1s',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="plan-select"
+                  value={plan.id}
+                  checked={selectedPlanId === plan.id}
+                  onChange={() => setSelectedPlanId(plan.id)}
+                  style={{ accentColor: 'var(--p)' }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div className="flex items-center gap-2">
+                    <span style={{ fontSize: 13.5, fontWeight: 600, color: 'var(--text)' }}>{plan.name}</span>
+                    {!plan.visibleToClinic && (
+                      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', padding: '1px 6px', borderRadius: 999, background: 'hsl(260 60% 95%)', color: 'hsl(260 50% 45%)', border: '1px solid hsl(260 50% 85%)' }}>
+                        Admin only
+                      </span>
+                    )}
+                    {plan.id === subscription.planId && (
+                      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', padding: '1px 6px', borderRadius: 999, background: 'var(--ok-soft)', color: 'var(--ok-ink)', border: '1px solid var(--ok-border)' }}>
+                        Atual
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>
+                    {formatCurrency(plan.priceMonthly)}/mês · {plan.maxUsers} usuários · {plan.maxPatients.toLocaleString('pt-BR')} pacientes
+                  </div>
+                </div>
+              </label>
+            ))}
+          </div>
+          <div className="flex justify-end gap-2" style={{ marginTop: 4 }}>
+            <button
+              disabled={!dirty || changePlan.isPending}
+              onClick={() => changePlan.mutate(selectedPlanId)}
+              style={{
+                display: 'inline-flex', alignItems: 'center', height: 32, padding: '0 14px', borderRadius: 8,
+                border: 'none', background: dirty ? 'var(--p)' : 'var(--surface-3)',
+                color: dirty ? 'white' : 'var(--text-faint)', fontSize: 13, fontWeight: 500,
+                cursor: dirty ? 'pointer' : 'not-allowed', fontFamily: 'var(--font-sans)',
+                boxShadow: dirty ? 'var(--shadow-brand)' : 'none', opacity: changePlan.isPending ? 0.6 : 1,
+              }}
+            >
+              {changePlan.isPending ? 'Salvando...' : 'Confirmar alteração'}
+            </button>
+          </div>
+        </div>
+      )}
+    </Card>
+  )
 }
 
 export function OrganizationDetailPage() {
@@ -303,15 +413,7 @@ export function OrganizationDetailPage() {
           )}
 
           {activeSubscription && (
-            <Card>
-              <CardHeader title="Assinatura atual" />
-              <div style={{ padding: 18, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
-                <FieldItem label="Plano" value={activeSubscription.plan?.name ?? '—'} />
-                <FieldItem label="Valor" value={activeSubscription.plan ? `${formatCurrency(activeSubscription.plan.priceMonthly)}/mês` : '—'} mono />
-                <FieldItem label="Início" value={formatDate(activeSubscription.startDate)} mono />
-                <FieldItem label="Status" value={activeSubscription.status} />
-              </div>
-            </Card>
+            <SubscriptionCard organizationId={id!} subscription={activeSubscription} />
           )}
         </div>
       </div>

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -58,8 +58,15 @@ function PlanCard({ plan, isHighlight }: { plan: Plan; isHighlight: boolean }) {
       <div style={{ padding: '22px 20px 18px', borderBottom: '1px solid var(--divider)' }}>
         <div className="flex items-start justify-between">
           <div>
-            <div style={{ fontSize: 16, fontWeight: 600, letterSpacing: '-0.012em', color: 'var(--text)', fontFamily: 'var(--font-display)' }}>
-              {plan.name}
+            <div className="flex items-center gap-2">
+              <div style={{ fontSize: 16, fontWeight: 600, letterSpacing: '-0.012em', color: 'var(--text)', fontFamily: 'var(--font-display)' }}>
+                {plan.name}
+              </div>
+              {!plan.visibleToClinic && (
+                <span style={{ fontSize: 10.5, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', padding: '2px 7px', borderRadius: 999, background: 'hsl(260 60% 95%)', color: 'hsl(260 50% 45%)', border: '1px solid hsl(260 50% 85%)', whiteSpace: 'nowrap' }}>
+                  Admin only
+                </span>
+              )}
             </div>
             <div style={{ fontSize: 12.5, color: 'var(--text-muted)', marginTop: 2 }}>
               {plan.maxPatients >= 999999

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -33,6 +33,7 @@ export interface Plan {
   maxPatients: number
   features: Record<string, boolean> | null
   isActive: boolean
+  visibleToClinic: boolean
   createdAt: string
 }
 


### PR DESCRIPTION
## Summary

- Adiciona campo `visibleToClinic` ao modelo `Plan` — quando `false`, o plano não aparece na interface da clínica (GET `/clinic-ext/plans` filtra por `visibleToClinic: true`)
- Admin pode alterar o plano de uma organização diretamente no painel via `PATCH /organizations/:id/subscription/plan`, sincronizando os limites com o pelvi-ui via `updateClinicAccess`
- Frontend: badge "Admin only" nos cards de plano, toggle no formulário de criação/edição, seletor de plano no detalhe da organização (exibe todos os planos, incluindo os admin-only)

## Detalhes técnicos

- **Migration** `20260519120000_add_plan_visible_to_clinic`: `ALTER TABLE plans ADD COLUMN visible_to_clinic BOOLEAN NOT NULL DEFAULT true`
- **`ChangePlanAdminUseCase`**: resolve org por `id` (admin DB), atualiza subscription, chama `clinicApi.updateClinicAccess` para propagar limites
- Endpoint restrito a `SUPER_ADMIN`
- Includes docs commit: atualiza CLAUDE.md para refletir deploy via Coolify e branch strategy main-only

## Test plan

- [ ] Criar plano com `visibleToClinic = false` → badge "Admin only" aparece na página de Planos
- [ ] Verificar que GET `/clinic-ext/plans` não retorna o plano oculto
- [ ] Na tela de detalhe de organização, clicar "Alterar plano" → todos os planos ativos aparecem (incluindo admin-only com badge)
- [ ] Selecionar plano diferente e confirmar → subscription atualiza, limites propagados ao pelvi-ui
- [ ] Tentativa de alterar para o plano já ativo retorna 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)