### PR TITLE
fix(metrics): don't reset startDate on plan change

### DIFF
--- a/backend/src/clinic-ext/clinic-ext.service.ts
+++ b/backend/src/clinic-ext/clinic-ext.service.ts
@@ -90,7 +90,6 @@ export class ClinicExtService {
         planId,
         status: 'ACTIVE',
         trialEndsAt: null,
-        startDate: new Date(),
         endDate: null,
       },
     })

--- a/backend/src/organizations/application/change-plan-admin.usecase.ts
+++ b/backend/src/organizations/application/change-plan-admin.usecase.ts
@@ -34,7 +34,7 @@ export class ChangePlanAdminUseCase {
 
     await this.prisma.subscription.update({
       where: { id: current.id },
-      data: { planId, status: 'ACTIVE', trialEndsAt: null, startDate: new Date(), endDate: null },
+      data: { planId, status: 'ACTIVE', trialEndsAt: null, endDate: null },
     })
 
     if (org.clinicExternalId) {

--- a/frontend/src/components/subscriptions/ChangePlanModal.tsx
+++ b/frontend/src/components/subscriptions/ChangePlanModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+import { formatCurrency, getErrorMessage } from '@/lib/utils'
+import { useToast } from '@/contexts/ToastContext'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import type { Plan, Subscription } from '@/types/admin'
+
+interface Props {
+  subscription: Subscription
+  open: boolean
+  onClose: () => void
+}
+
+export function ChangePlanModal({ subscription, open, onClose }: Props) {
+  const [selectedPlanId, setSelectedPlanId] = useState(subscription.planId)
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const { data: plans } = useQuery<Plan[]>({
+    queryKey: ['plans'],
+    queryFn: () => api.get('/plans').then((r) => r.data),
+    enabled: open,
+  })
+
+  const activePlans = plans?.filter((p) => p.isActive) ?? []
+  const dirty = selectedPlanId !== subscription.planId
+
+  const changePlan = useMutation({
+    mutationFn: (planId: string) =>
+      api.patch(`/organizations/${subscription.organizationId}/subscription/plan`, { planId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['subscriptions'] })
+      toast.success('Plano alterado com sucesso')
+      onClose()
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  })
+
+  function handleOpenChange(v: boolean) {
+    if (!v) {
+      setSelectedPlanId(subscription.planId)
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent title={`Alterar plano · ${subscription.organization?.name ?? '—'}`}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>
+            Plano atual: <strong style={{ color: 'var(--text)' }}>{subscription.plan?.name ?? '—'}</strong>
+          </p>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {activePlans.map((plan) => (
+              <label
+                key={plan.id}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', borderRadius: 8,
+                  border: `1px solid ${selectedPlanId === plan.id ? 'var(--p-border)' : 'var(--ds-border)'}`,
+                  background: selectedPlanId === plan.id ? 'hsl(16 65% 44% / 0.05)' : 'var(--surface)',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="plan-select"
+                  value={plan.id}
+                  checked={selectedPlanId === plan.id}
+                  onChange={() => setSelectedPlanId(plan.id)}
+                  style={{ accentColor: 'var(--p)', flexShrink: 0 }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div className="flex items-center gap-2">
+                    <span style={{ fontSize: 13.5, fontWeight: 600, color: 'var(--text)' }}>{plan.name}</span>
+                    {!plan.visibleToClinic && (
+                      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', padding: '1px 6px', borderRadius: 999, background: 'hsl(260 60% 95%)', color: 'hsl(260 50% 45%)', border: '1px solid hsl(260 50% 85%)' }}>
+                        Admin only
+                      </span>
+                    )}
+                    {plan.id === subscription.planId && (
+                      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', padding: '1px 6px', borderRadius: 999, background: 'var(--ok-soft)', color: 'var(--ok-ink)', border: '1px solid var(--ok-border)' }}>
+                        Atual
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>
+                    {formatCurrency(plan.priceMonthly)}/mês · {plan.maxUsers} usuários · {plan.maxPatients.toLocaleString('pt-BR')} pacientes
+                  </div>
+                </div>
+              </label>
+            ))}
+          </div>
+
+          <div className="flex justify-end gap-2" style={{ marginTop: 4 }}>
+            <button
+              onClick={() => handleOpenChange(false)}
+              style={{ display: 'inline-flex', alignItems: 'center', height: 32, padding: '0 14px', borderRadius: 8, border: '1px solid var(--ds-border)', background: 'var(--surface)', fontSize: 13, fontWeight: 500, cursor: 'pointer', color: 'var(--text)', fontFamily: 'var(--font-sans)' }}
+            >
+              Cancelar
+            </button>
+            <button
+              disabled={!dirty || changePlan.isPending}
+              onClick={() => changePlan.mutate(selectedPlanId)}
+              style={{
+                display: 'inline-flex', alignItems: 'center', height: 32, padding: '0 14px', borderRadius: 8,
+                border: 'none', background: dirty ? 'var(--p)' : 'var(--surface-3)',
+                color: dirty ? 'white' : 'var(--text-faint)', fontSize: 13, fontWeight: 500,
+                cursor: dirty ? 'pointer' : 'not-allowed', fontFamily: 'var(--font-sans)',
+                boxShadow: dirty ? 'var(--shadow-brand)' : 'none', opacity: changePlan.isPending ? 0.6 : 1,
+              }}
+            >
+              {changePlan.isPending ? 'Salvando...' : 'Confirmar alteração'}
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/Organizations.tsx
+++ b/frontend/src/pages/Organizations.tsx
@@ -91,7 +91,6 @@ export function OrganizationsPage() {
                 <th>Organização</th>
                 <th>CNPJ</th>
                 <th style={{ textAlign: 'right' }}>MRR</th>
-                <th style={{ textAlign: 'right' }}>Usuários</th>
                 <th>Status</th>
                 <th>Cliente desde</th>
                 <th style={{ width: 32 }} />
@@ -101,7 +100,7 @@ export function OrganizationsPage() {
               {isLoading ? (
                 Array.from({ length: 6 }).map((_, i) => (
                   <tr key={i}>
-                    {Array.from({ length: 8 }).map((_, j) => (
+                    {Array.from({ length: 7 }).map((_, j) => (
                       <td key={j}><Skeleton className="h-4 w-full" /></td>
                     ))}
                   </tr>
@@ -126,7 +125,6 @@ export function OrganizationsPage() {
                   <td className="num" style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-2)' }}>
                     {org.mrr != null ? formatCurrency(org.mrr) : '—'}
                   </td>
-                  <td className="num" style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-2)' }}>—</td>
                   <td>
                     {org.status === 'ACTIVE'    ? <StatusPill tone="ok">Ativa</StatusPill>
                       : org.status === 'SUSPENDED' ? <StatusPill tone="warn">Suspensa</StatusPill>
@@ -144,7 +142,7 @@ export function OrganizationsPage() {
               ))}
               {!isLoading && orgs.length === 0 && (
                 <tr>
-                  <td colSpan={8} style={{ padding: '32px 16px', textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+                  <td colSpan={7} style={{ padding: '32px 16px', textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
                     Nenhuma organização encontrada
                   </td>
                 </tr>

--- a/frontend/src/pages/Subscriptions.tsx
+++ b/frontend/src/pages/Subscriptions.tsx
@@ -4,6 +4,7 @@ import { formatDate, formatCurrency } from '@/lib/utils'
 import type { Subscription, SubscriptionStatus } from '@/types/admin'
 import { Skeleton } from '@/components/ui/skeleton'
 import { CreateSubscriptionModal } from '@/components/subscriptions/CreateSubscriptionModal'
+import { ChangePlanModal } from '@/components/subscriptions/ChangePlanModal'
 import { OrgAvatar, StatusPill, PlanBadge, PageHeader, Card, SearchInput, FilterChip, TableFooter } from '@/components/ui/ds'
 import { useState } from 'react'
 
@@ -30,6 +31,7 @@ function SubStatusPill({ status }: { status: SubscriptionStatus }) {
 export function SubscriptionsPage() {
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [changingPlan, setChangingPlan] = useState<Subscription | null>(null)
 
   const { data: subscriptionsResp, isLoading, error } = useQuery<{ data: Subscription[]; total: number }>({
     queryKey: ['subscriptions'],
@@ -99,6 +101,14 @@ export function SubscriptionsPage() {
         <SearchInput value={search} onChange={setSearch} placeholder="Buscar por organização ou plano…" />
       </div>
 
+      {changingPlan && (
+        <ChangePlanModal
+          subscription={changingPlan}
+          open={!!changingPlan}
+          onClose={() => setChangingPlan(null)}
+        />
+      )}
+
       <Card style={{ display: 'flex', flexDirection: 'column' }}>
         <div style={{ flex: 1, overflow: 'auto' }}>
           <table className="pa-tbl">
@@ -146,9 +156,15 @@ export function SubscriptionsPage() {
                     {sub.trialEndsAt ? formatDate(sub.trialEndsAt) : '—'}
                   </td>
                   <td>
-                    <button style={{ width: 26, height: 26, display: 'grid', placeItems: 'center', border: 0, background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--text-muted)' }}>
-                      <MoreIcon />
-                    </button>
+                    {(sub.status === 'ACTIVE' || sub.status === 'TRIAL') && (
+                      <button
+                        onClick={() => setChangingPlan(sub)}
+                        style={{ width: 26, height: 26, display: 'grid', placeItems: 'center', border: 0, background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--text-muted)' }}
+                        title="Alterar plano"
+                      >
+                        <MoreIcon />
+                      </button>
+                    )}
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
changePlan was setting startDate = now() on every plan switch, which caused the conversion funnel to count the subscription as a brand-new trial in the current period (trialsStarted+1, converted+1), removing it from its original cohort and artificially inflating conversion rate.

startDate represents when the customer first subscribed, not when they last changed plans. Plan change history is already tracked via OrgEvent PLAN_CHANGED.