### PR TITLE
feat(plans): migrar features de Record<string,boolean> para string[]

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -9,35 +9,53 @@ const prisma = new PrismaClient({ adapter })
 async function main() {
   console.log('🌱 Seeding admin database...')
 
-  // Planos padrão
+  // Planos padrão — features como array de PlanFeatureKey (alinhado com pelvi-ui)
   const plans = [
     {
       name: 'Trial',
       priceMonthly: 0,
-      maxUsers: 3,
-      maxPatients: 50,
-      features: { nfse: false, whatsapp: false, reports: false, trial: true },
+      maxUsers: 4,
+      maxPatients: 999999,
+      isActive: true,
+      visibleToClinic: false,
+      features: [
+        'AGENDA', 'PATIENTS', 'FINANCIAL_BASIC',
+        'PERINEAL_ASSESSMENT', 'TREATMENT_PACKAGES', 'EVOLUTIONS',
+        'FINANCIAL_ADVANCED', 'ANAMNESIS', 'ROLES', 'MULTI_PROFESSIONAL',
+      ],
     },
     {
-      name: 'Básico',
-      priceMonthly: 97,
-      maxUsers: 3,
-      maxPatients: 200,
-      features: { nfse: false, whatsapp: false, reports: true },
-    },
-    {
-      name: 'Profissional',
-      priceMonthly: 197,
-      maxUsers: 10,
-      maxPatients: 1000,
-      features: { nfse: true, whatsapp: false, reports: true },
+      name: 'Solo',
+      priceMonthly: 89,
+      maxUsers: 1,
+      maxPatients: 999999,
+      features: [
+        'AGENDA', 'PATIENTS', 'FINANCIAL_BASIC',
+        'PERINEAL_ASSESSMENT', 'TREATMENT_PACKAGES', 'EVOLUTIONS',
+      ],
     },
     {
       name: 'Clínica',
-      priceMonthly: 397,
-      maxUsers: 999,
+      priceMonthly: 179,
+      maxUsers: 4,
       maxPatients: 999999,
-      features: { nfse: true, whatsapp: true, reports: true },
+      features: [
+        'AGENDA', 'PATIENTS', 'FINANCIAL_BASIC', 'FINANCIAL_ADVANCED',
+        'PERINEAL_ASSESSMENT', 'TREATMENT_PACKAGES', 'ANAMNESIS',
+        'EVOLUTIONS', 'ROLES', 'MULTI_PROFESSIONAL',
+      ],
+    },
+    {
+      name: 'Rede',
+      priceMonthly: 349,
+      maxUsers: 10,
+      maxPatients: 999999,
+      features: [
+        'AGENDA', 'PATIENTS', 'FINANCIAL_BASIC', 'FINANCIAL_ADVANCED',
+        'PERINEAL_ASSESSMENT', 'TREATMENT_PACKAGES', 'ANAMNESIS',
+        'EVOLUTIONS', 'ROLES', 'MULTI_PROFESSIONAL',
+        'MULTI_CLINIC', 'PRIORITY_SUPPORT',
+      ],
     },
   ]
 

--- a/backend/src/plans/dto/create-plan.dto.ts
+++ b/backend/src/plans/dto/create-plan.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNumber, IsOptional, IsBoolean, Min, IsObject } from 'class-validator'
+import { IsString, IsNumber, IsOptional, IsBoolean, Min, IsArray } from 'class-validator'
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { Type } from 'class-transformer'
 
@@ -25,10 +25,14 @@ export class CreatePlanDto {
   @Min(1)
   maxPatients: number
 
-  @ApiPropertyOptional({ example: { nfse: true, whatsapp: false } })
+  @ApiPropertyOptional({
+    example: ['AGENDA', 'PATIENTS', 'FINANCIAL_BASIC', 'EVOLUTIONS'],
+    description: 'Feature keys habilitadas neste plano (ver PlanFeature em pelvi-ui)',
+  })
   @IsOptional()
-  @IsObject()
-  features?: Record<string, boolean>
+  @IsArray()
+  @IsString({ each: true })
+  features?: string[]
 
   @ApiPropertyOptional({ default: true })
   @IsOptional()

--- a/frontend/src/components/plans/PlanFormModal.tsx
+++ b/frontend/src/components/plans/PlanFormModal.tsx
@@ -10,14 +10,22 @@ import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import type { Plan } from '@/types/admin'
+import type { Plan, PlanFeatureKey } from '@/types/admin'
 import { Plus, Pencil } from 'lucide-react'
 
-const FEATURES = [
-  { key: 'nfse', label: 'Nota Fiscal (NFS-e)' },
-  { key: 'whatsapp', label: 'WhatsApp' },
-  { key: 'agendamento_online', label: 'Agendamento Online' },
-  { key: 'relatorios', label: 'Relatórios Avançados' },
+const ALL_FEATURES: { key: PlanFeatureKey; label: string }[] = [
+  { key: 'AGENDA',               label: 'Agenda' },
+  { key: 'PATIENTS',             label: 'Pacientes (ilimitados)' },
+  { key: 'FINANCIAL_BASIC',      label: 'Financeiro básico' },
+  { key: 'FINANCIAL_ADVANCED',   label: 'Relatórios financeiros avançados' },
+  { key: 'PERINEAL_ASSESSMENT',  label: 'Avaliação perineal' },
+  { key: 'TREATMENT_PACKAGES',   label: 'Pacotes de tratamento' },
+  { key: 'ANAMNESIS',            label: 'Anamnese personalizada' },
+  { key: 'EVOLUTIONS',           label: 'Prontuários e evoluções' },
+  { key: 'ROLES',                label: 'Perfis por função (Admin/Prof/Recep)' },
+  { key: 'MULTI_PROFESSIONAL',   label: 'Múltiplos profissionais' },
+  { key: 'MULTI_CLINIC',         label: 'Multi-clínica' },
+  { key: 'PRIORITY_SUPPORT',     label: 'Suporte prioritário' },
 ]
 
 const schema = z.object({
@@ -37,7 +45,7 @@ interface Props {
 
 export function PlanFormModal({ plan }: Props) {
   const [open, setOpen] = useState(false)
-  const [features, setFeatures] = useState<Record<string, boolean>>({})
+  const [selectedFeatures, setSelectedFeatures] = useState<Set<PlanFeatureKey>>(new Set())
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const isEditing = !!plan
@@ -50,35 +58,49 @@ export function PlanFormModal({ plan }: Props) {
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: plan
-      ? { name: plan.name, priceMonthly: plan.priceMonthly, maxUsers: plan.maxUsers, maxPatients: plan.maxPatients, isActive: plan.isActive, visibleToClinic: plan.visibleToClinic }
+      ? {
+          name: plan.name,
+          priceMonthly: plan.priceMonthly,
+          maxUsers: plan.maxUsers,
+          maxPatients: plan.maxPatients,
+          isActive: plan.isActive,
+          visibleToClinic: plan.visibleToClinic,
+        }
       : { isActive: true, visibleToClinic: true },
   })
 
   useEffect(() => {
     if (open && plan?.features) {
-      setFeatures(plan.features)
+      setSelectedFeatures(new Set(plan.features))
     } else if (!open) {
-      setFeatures({})
+      setSelectedFeatures(new Set())
+      reset()
     }
-  }, [open, plan])
+  }, [open, plan, reset])
+
+  const toggleFeature = (key: PlanFeatureKey) => {
+    setSelectedFeatures((prev) => {
+      const next = new Set(prev)
+      next.has(key) ? next.delete(key) : next.add(key)
+      return next
+    })
+  }
 
   const mutation = useMutation({
     mutationFn: (data: FormData) => {
-      const body = { ...data, features: Object.keys(features).length > 0 ? features : undefined }
-      return isEditing ? api.patch(`/plans/${plan.id}`, body) : api.post('/plans', body)
+      const features = selectedFeatures.size > 0 ? [...selectedFeatures] : undefined
+      const body = { ...data, features }
+      return isEditing
+        ? api.patch(`/plans/${plan.id}`, body)
+        : api.post('/plans', body)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plans'] })
       toast.success(isEditing ? 'Plano atualizado' : 'Plano criado com sucesso')
-      reset()
       setOpen(false)
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   })
-
-  const toggleFeature = (key: string) => {
-    setFeatures((prev) => ({ ...prev, [key]: !prev[key] }))
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -99,37 +121,90 @@ export function PlanFormModal({ plan }: Props) {
         <form onSubmit={handleSubmit((d) => mutation.mutate(d))} className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="plan-name">Nome *</Label>
-            <Input id="plan-name" placeholder="Profissional" {...register('name')} error={errors.name?.message} />
+            <Input
+              id="plan-name"
+              placeholder="Profissional"
+              {...register('name')}
+              error={errors.name?.message}
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label htmlFor="price">Preço/mês (R$) *</Label>
-              <Input id="price" type="number" step="0.01" placeholder="197.00" {...register('priceMonthly')} error={errors.priceMonthly?.message} />
+              <Input
+                id="price"
+                type="number"
+                step="0.01"
+                placeholder="197.00"
+                {...register('priceMonthly')}
+                error={errors.priceMonthly?.message}
+              />
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="maxUsers">Máx. usuários *</Label>
-              <Input id="maxUsers" type="number" placeholder="10" {...register('maxUsers')} error={errors.maxUsers?.message} />
+              <Input
+                id="maxUsers"
+                type="number"
+                placeholder="10"
+                {...register('maxUsers')}
+                error={errors.maxUsers?.message}
+              />
             </div>
           </div>
 
           <div className="space-y-1.5">
             <Label htmlFor="maxPatients">Máx. pacientes *</Label>
-            <Input id="maxPatients" type="number" placeholder="1000" {...register('maxPatients')} error={errors.maxPatients?.message} />
+            <Input
+              id="maxPatients"
+              type="number"
+              placeholder="1000"
+              {...register('maxPatients')}
+              error={errors.maxPatients?.message}
+            />
           </div>
 
           <div className="space-y-2">
-            <Label>Funcionalidades</Label>
-            <div className="grid grid-cols-2 gap-2">
-              {FEATURES.map(({ key, label }) => (
-                <label key={key} className="flex items-center gap-2 text-sm cursor-pointer">
+            <div className="flex items-center justify-between">
+              <Label>
+                Funcionalidades
+                <span style={{ marginLeft: 6, fontSize: 11.5, color: 'var(--text-muted)', fontWeight: 400 }}>
+                  ({selectedFeatures.size} selecionadas)
+                </span>
+              </Label>
+            </div>
+            <div
+              style={{
+                border: '1px solid var(--ds-border)',
+                borderRadius: 8,
+                overflow: 'hidden',
+                maxHeight: 260,
+                overflowY: 'auto',
+              }}
+            >
+              {ALL_FEATURES.map(({ key, label }, i) => (
+                <label
+                  key={key}
+                  className="flex items-center gap-2.5 cursor-pointer"
+                  style={{
+                    padding: '7px 12px',
+                    fontSize: 13,
+                    borderBottom: i < ALL_FEATURES.length - 1 ? '1px solid var(--divider)' : 'none',
+                    background: selectedFeatures.has(key) ? 'var(--ok-soft)' : 'transparent',
+                    color: selectedFeatures.has(key) ? 'var(--ok-ink)' : 'var(--text)',
+                    transition: 'background 0.1s',
+                  }}
+                >
                   <input
                     type="checkbox"
-                    checked={!!features[key]}
+                    checked={selectedFeatures.has(key)}
                     onChange={() => toggleFeature(key)}
-                    className="rounded border-input"
+                    style={{ accentColor: 'var(--p)', flexShrink: 0 }}
                   />
-                  {label}
+                  <span style={{ flex: 1 }}>{label}</span>
+                  <code style={{ fontSize: 10.5, color: 'var(--text-faint)', fontFamily: 'var(--font-mono)' }}>
+                    {key}
+                  </code>
                 </label>
               ))}
             </div>
@@ -143,7 +218,9 @@ export function PlanFormModal({ plan }: Props) {
             <label className="flex items-center gap-2 text-sm cursor-pointer">
               <input type="checkbox" {...register('visibleToClinic')} className="rounded border-input" />
               <span>Visível na interface da clínica</span>
-              <span style={{ fontSize: 11.5, color: 'var(--text-muted)', marginLeft: 2 }}>(desmarcar = somente via admin)</span>
+              <span style={{ fontSize: 11.5, color: 'var(--text-muted)', marginLeft: 2 }}>
+                (desmarcar = somente via admin)
+              </span>
             </label>
           </div>
 
@@ -152,7 +229,11 @@ export function PlanFormModal({ plan }: Props) {
               Cancelar
             </Button>
             <Button type="submit" disabled={mutation.isPending}>
-              {mutation.isPending ? 'Salvando...' : isEditing ? 'Salvar Alterações' : 'Criar Plano'}
+              {mutation.isPending
+                ? 'Salvando...'
+                : isEditing
+                ? 'Salvar Alterações'
+                : 'Criar Plano'}
             </Button>
           </div>
         </form>

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -1,18 +1,28 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
-import type { Plan } from '@/types/admin'
+import type { Plan, PlanFeatureKey } from '@/types/admin'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlanFormModal } from '@/components/plans/PlanFormModal'
 import { StatusPill, PageHeader } from '@/components/ui/ds'
 
+const FEATURE_LABELS: Record<PlanFeatureKey, string> = {
+  AGENDA:              'Agenda',
+  PATIENTS:            'Pacientes (ilimitados)',
+  FINANCIAL_BASIC:     'Financeiro básico',
+  FINANCIAL_ADVANCED:  'Relatórios financeiros avançados',
+  PERINEAL_ASSESSMENT: 'Avaliação perineal',
+  TREATMENT_PACKAGES:  'Pacotes de tratamento',
+  ANAMNESIS:           'Anamnese personalizada',
+  EVOLUTIONS:          'Prontuários e evoluções',
+  ROLES:               'Perfis por função',
+  MULTI_PROFESSIONAL:  'Múltiplos profissionais',
+  MULTI_CLINIC:        'Multi-clínica',
+  PRIORITY_SUPPORT:    'Suporte prioritário',
+}
+
 const CheckIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ width: 10, height: 10 }}>
     <path d="M5 12.5 10 17.5l9-11"/>
-  </svg>
-)
-const XIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ width: 8, height: 8 }}>
-    <path d="M6 6l12 12M18 6 6 18"/>
   </svg>
 )
 const ClockIcon = () => (
@@ -100,23 +110,23 @@ function PlanCard({ plan, isHighlight }: { plan: Plan; isHighlight: boolean }) {
       </div>
 
       {/* Features */}
-      {plan.features && (
+      {plan.features && plan.features.length > 0 && (
         <div style={{ padding: '12px 20px 16px' }}>
           <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase', marginBottom: 8 }}>
-            Funcionalidades
+            Funcionalidades ({plan.features.length})
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {Object.entries(plan.features).map(([key, enabled]) => (
-              <div key={key} className="flex items-center gap-2" style={{ fontSize: 12.5, color: enabled ? 'var(--text)' : 'var(--text-faint)' }}>
+            {plan.features.map((key) => (
+              <div key={key} className="flex items-center gap-2" style={{ fontSize: 12.5, color: 'var(--text)' }}>
                 <span style={{
                   width: 16, height: 16, borderRadius: 4,
                   display: 'grid', placeItems: 'center', flexShrink: 0,
-                  background: enabled ? 'var(--ok-soft)' : 'var(--surface-3)',
-                  color: enabled ? 'var(--ok-ink)' : 'var(--text-faint)',
+                  background: 'var(--ok-soft)',
+                  color: 'var(--ok-ink)',
                 }}>
-                  {enabled ? <CheckIcon /> : <XIcon />}
+                  <CheckIcon />
                 </span>
-                {key}
+                {FEATURE_LABELS[key as PlanFeatureKey] ?? key}
               </div>
             ))}
           </div>

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -25,13 +25,28 @@ export interface Organization {
   userCount?: number | null
 }
 
+// Feature keys habilitadas num plano — alinhado com PlanFeature em pelvi-ui
+export type PlanFeatureKey =
+  | 'AGENDA'
+  | 'PATIENTS'
+  | 'FINANCIAL_BASIC'
+  | 'FINANCIAL_ADVANCED'
+  | 'PERINEAL_ASSESSMENT'
+  | 'TREATMENT_PACKAGES'
+  | 'ANAMNESIS'
+  | 'EVOLUTIONS'
+  | 'ROLES'
+  | 'MULTI_PROFESSIONAL'
+  | 'MULTI_CLINIC'
+  | 'PRIORITY_SUPPORT'
+
 export interface Plan {
   id: string
   name: string
   priceMonthly: number
   maxUsers: number
   maxPatients: number
-  features: Record<string, boolean> | null
+  features: PlanFeatureKey[] | null
   isActive: boolean
   visibleToClinic: boolean
   createdAt: string


### PR DESCRIPTION
## Resumo

Alinha o formato do campo `Plan.features` com o que o pelvi-ui espera: um **array de feature keys habilitadas** (`string[]`) em vez do objeto booleano anterior (`{ nfse: true, whatsapp: false }`).

Pré-requisito para o feature gating do pelvi-ui funcionar corretamente — o `SubscriptionService` no pelvi-ui lê `subscription.plan.features` e espera um array de strings.

## Mudanças

### Backend
- `CreatePlanDto.features` — de `@IsObject()` / `Record<string, boolean>` para `@IsArray()` + `@IsString({ each: true })`
- `seed.ts` — planos atualizados para Solo / Clínica / Rede com arrays de features alinhados ao `subscription-strategy.md`; Trial com acesso plano Clínica (não visível à clínica)

### Frontend
- `types/admin.ts` — novo tipo `PlanFeatureKey` (12 chaves) + `Plan.features: PlanFeatureKey[] | null`
- `PlanFormModal` — seleção via checkboxes das 12 feature keys do pelvi-ui, com label em PT-BR e code da chave visível; persiste como array de habilitadas
- `Plans.tsx` (`PlanCard`) — renderiza features como lista de itens habilitados com `FEATURE_LABELS`; removido `XIcon` (itens desabilitados não aparecem mais — irrelevante num array)

## Atenção pós-merge

Planos já existentes no banco de produção têm `features` no formato antigo (`{ nfse: true, ... }`). Precisam ser editados via interface admin (Plans page → editar → salvar) ou via re-seed em dev antes do pelvi-ui consumir as features via `GET /api/clinic-ext/subscription`.

## Dependência

- pelvi-ui PR #73 — `feat(subscription): feature gating por plano`

🤖 Generated with [Claude Code](https://claude.com/claude-code)