### PR TITLE
fix(plans): corrigir TypeError ao editar plano com features no formato antigo

### DIFF
--- a/frontend/src/components/plans/PlanFormModal.tsx
+++ b/frontend/src/components/plans/PlanFormModal.tsx
@@ -71,7 +71,13 @@ export function PlanFormModal({ plan }: Props) {
 
   useEffect(() => {
     if (open && plan?.features) {
-      setSelectedFeatures(new Set(plan.features))
+      // Compatibilidade com planos antigos cujo features ainda é { nfse: true, ... }
+      const keys: PlanFeatureKey[] = Array.isArray(plan.features)
+        ? plan.features
+        : Object.entries(plan.features as unknown as Record<string, boolean>)
+            .filter(([, v]) => v)
+            .map(([k]) => k as PlanFeatureKey)
+      setSelectedFeatures(new Set(keys))
     } else if (!open) {
       setSelectedFeatures(new Set())
       reset()


### PR DESCRIPTION
## Problema

Ao abrir o modal de edição de um plano cujo campo `features` ainda está no formato legado (`{ nfse: true, whatsapp: false }`), o console lança:

```
TypeError: plan.features is not iterable
```

O construtor `new Set(plan.features)` espera um iterável — um objeto plano não é iterável.

## Causa

O PR #134 migrou o formato de `features` para `string[]`, mas planos já existentes no banco de produção continuam com o formato antigo até serem re-salvos via interface.

## Fix

Detecta o formato em runtime antes de inicializar o `Set`:

```ts
const keys = Array.isArray(plan.features)
  ? plan.features
  : Object.entries(plan.features as Record<string, boolean>)
      .filter(([, v]) => v)
      .map(([k]) => k as PlanFeatureKey)
setSelectedFeatures(new Set(keys))
```

Planos no formato antigo continuam editáveis e mostram corretamente as features que estavam `true`.

## Contexto

Fix que ficou fora do merge do #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)