### PR TITLE
feat(plan-features): implement plan feature definitions management

### DIFF
--- a/backend/prisma/migrations/20260525120000_add_plan_feature_definitions/migration.sql
+++ b/backend/prisma/migrations/20260525120000_add_plan_feature_definitions/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "plan_feature_definitions" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "description" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "plan_feature_definitions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "plan_feature_definitions_key_key" ON "plan_feature_definitions"("key");
+
+-- CreateIndex
+CREATE INDEX "plan_feature_definitions_active_idx" ON "plan_feature_definitions"("active");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -88,6 +88,25 @@ model Organization {
 }
 
 // ──────────────────────────────────────────────
+// PlanFeatureDefinition — catálogo de features disponíveis no sistema
+// Single source of truth; planos referenciam as keys dessa tabela via JSONB
+// ──────────────────────────────────────────────
+
+model PlanFeatureDefinition {
+  id          String   @id @default(uuid())
+  key         String   @unique
+  label       String
+  description String?
+  active      Boolean  @default(true)
+  sortOrder   Int      @default(0) @map("sort_order")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@index([active])
+  @@map("plan_feature_definitions")
+}
+
+// ──────────────────────────────────────────────
 // Plan — planos de assinatura
 // ──────────────────────────────────────────────
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -6,8 +6,34 @@ import { randomBytes } from 'crypto'
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_ADMIN_URL! })
 const prisma = new PrismaClient({ adapter })
 
+const FEATURE_DEFINITIONS = [
+  { key: 'AGENDA',              label: 'Agenda',                              description: 'Agendamento de consultas com visões dia/semana/mês e drag-and-drop',       sortOrder: 1 },
+  { key: 'PATIENTS',            label: 'Pacientes (ilimitados)',               description: 'Cadastro e gestão completa de pacientes com histórico clínico',            sortOrder: 2 },
+  { key: 'FINANCIAL_BASIC',     label: 'Financeiro básico',                   description: 'Registro de receitas e despesas vinculadas a consultas e pacientes',       sortOrder: 3 },
+  { key: 'FINANCIAL_ADVANCED',  label: 'Relatórios financeiros avançados',    description: 'Resumos mensais, extratos e análises financeiras avançadas',               sortOrder: 4 },
+  { key: 'PERINEAL_ASSESSMENT', label: 'Avaliação perineal',                  description: 'Wizard de avaliação do assoalho pélvico em 6 etapas com dados flexíveis',  sortOrder: 5 },
+  { key: 'TREATMENT_PACKAGES',  label: 'Pacotes de tratamento',               description: 'Criação e controle de pacotes de sessões por paciente',                    sortOrder: 6 },
+  { key: 'ANAMNESIS',           label: 'Anamnese personalizada',              description: 'Formulários de anamnese com estrutura livre em JSON por clínica',          sortOrder: 7 },
+  { key: 'EVOLUTIONS',          label: 'Prontuários e evoluções',             description: 'Linha do tempo de evoluções clínicas vinculadas a consultas',              sortOrder: 8 },
+  { key: 'ROLES',               label: 'Perfis por função',                   description: 'Controle de acesso por papel: Admin, Profissional e Recepcionista',        sortOrder: 9 },
+  { key: 'MULTI_PROFESSIONAL',  label: 'Múltiplos profissionais',             description: 'Gestão de equipe com vários profissionais na mesma clínica',               sortOrder: 10 },
+  { key: 'MULTI_CLINIC',        label: 'Multi-clínica',                       description: 'Um usuário administrador gerenciando múltiplas unidades',                  sortOrder: 11 },
+  { key: 'PRIORITY_SUPPORT',    label: 'Suporte prioritário',                 description: 'Atendimento prioritário por canais dedicados',                             sortOrder: 12 },
+  { key: 'DOCUMENTS',           label: 'Módulo de Documentos',                description: 'Geração e armazenamento de documentos PDF para pacientes',                 sortOrder: 13 },
+]
+
 async function main() {
   console.log('🌱 Seeding admin database...')
+
+  // Feature definitions — single source of truth para features disponíveis no sistema
+  for (const feature of FEATURE_DEFINITIONS) {
+    await prisma.planFeatureDefinition.upsert({
+      where: { key: feature.key },
+      update: { label: feature.label, description: feature.description, sortOrder: feature.sortOrder },
+      create: feature,
+    })
+  }
+  console.log(`✅ ${FEATURE_DEFINITIONS.length} feature definitions sincronizadas`)
 
   // Planos padrão — features como array de PlanFeatureKey (alinhado com pelvi-ui)
   const plans = [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { MetricsModule } from './metrics/metrics.module'
 import { ClinicApiModule } from './clinic-api/clinic-api.module'
 import { HealthModule } from './health/health.module'
 import { ClinicExtModule } from './clinic-ext/clinic-ext.module'
+import { PlanFeaturesModule } from './plan-features/plan-features.module'
 import { CorrelationIdMiddleware } from './common/correlation/correlation-id.middleware'
 
 @Module({
@@ -46,6 +47,7 @@ import { CorrelationIdMiddleware } from './common/correlation/correlation-id.mid
     AuthModule,
     OrganizationsModule,
     PlansModule,
+    PlanFeaturesModule,
     SubscriptionsModule,
     InvoicesModule,
     MetricsModule,

--- a/backend/src/plan-features/dto/create-plan-feature.dto.ts
+++ b/backend/src/plan-features/dto/create-plan-feature.dto.ts
@@ -1,0 +1,33 @@
+import { IsString, IsOptional, IsBoolean, IsInt, Min, MinLength, Matches } from 'class-validator'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { Type } from 'class-transformer'
+
+export class CreatePlanFeatureDto {
+  @ApiProperty({ example: 'DOCUMENTS', description: 'Chave única em UPPER_SNAKE_CASE' })
+  @IsString()
+  @MinLength(2)
+  @Matches(/^[A-Z][A-Z0-9_]*$/, { message: 'key deve ser UPPER_SNAKE_CASE (ex: DOCUMENTS, FINANCIAL_BASIC)' })
+  key: string
+
+  @ApiProperty({ example: 'Módulo de Documentos' })
+  @IsString()
+  @MinLength(2)
+  label: string
+
+  @ApiPropertyOptional({ example: 'Permite gerar e armazenar documentos em PDF para pacientes' })
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean
+
+  @ApiPropertyOptional({ default: 0, description: 'Ordem de exibição nas listagens' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  sortOrder?: number
+}

--- a/backend/src/plan-features/dto/update-plan-feature.dto.ts
+++ b/backend/src/plan-features/dto/update-plan-feature.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType, OmitType } from '@nestjs/swagger'
+import { CreatePlanFeatureDto } from './create-plan-feature.dto'
+
+export class UpdatePlanFeatureDto extends PartialType(OmitType(CreatePlanFeatureDto, ['key'] as const)) {}

--- a/backend/src/plan-features/plan-features.controller.ts
+++ b/backend/src/plan-features/plan-features.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Post, Patch, Delete, Body, Param, ParseUUIDPipe, UseGuards, Query } from '@nestjs/common'
+import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { PlanFeaturesService } from './plan-features.service'
+import { CreatePlanFeatureDto } from './dto/create-plan-feature.dto'
+import { UpdatePlanFeatureDto } from './dto/update-plan-feature.dto'
+
+@ApiTags('plan-features')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('plan-features')
+export class PlanFeaturesController {
+  constructor(private readonly planFeaturesService: PlanFeaturesService) {}
+
+  @Get()
+  @ApiQuery({ name: 'includeInactive', required: false, type: Boolean })
+  findAll(@Query('includeInactive') includeInactive?: string) {
+    return this.planFeaturesService.findAll(includeInactive === 'true')
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.planFeaturesService.findOne(id)
+  }
+
+  @Post()
+  @Roles('SUPER_ADMIN')
+  create(@Body() dto: CreatePlanFeatureDto) {
+    return this.planFeaturesService.create(dto)
+  }
+
+  @Patch(':id')
+  @Roles('SUPER_ADMIN')
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdatePlanFeatureDto) {
+    return this.planFeaturesService.update(id, dto)
+  }
+
+  @Delete(':id')
+  @Roles('SUPER_ADMIN')
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.planFeaturesService.remove(id)
+  }
+}

--- a/backend/src/plan-features/plan-features.module.ts
+++ b/backend/src/plan-features/plan-features.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { PlanFeaturesController } from './plan-features.controller'
+import { PlanFeaturesService } from './plan-features.service'
+
+@Module({
+  controllers: [PlanFeaturesController],
+  providers: [PlanFeaturesService],
+  exports: [PlanFeaturesService],
+})
+export class PlanFeaturesModule {}

--- a/backend/src/plan-features/plan-features.service.ts
+++ b/backend/src/plan-features/plan-features.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { CreatePlanFeatureDto } from './dto/create-plan-feature.dto'
+import { UpdatePlanFeatureDto } from './dto/update-plan-feature.dto'
+
+@Injectable()
+export class PlanFeaturesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll(includeInactive = false) {
+    return this.prisma.planFeatureDefinition.findMany({
+      where: includeInactive ? undefined : { active: true },
+      orderBy: [{ sortOrder: 'asc' }, { label: 'asc' }],
+    })
+  }
+
+  async findOne(id: string) {
+    const feature = await this.prisma.planFeatureDefinition.findUnique({ where: { id } })
+    if (!feature) throw new NotFoundException('Feature não encontrada')
+    return feature
+  }
+
+  async create(dto: CreatePlanFeatureDto) {
+    const exists = await this.prisma.planFeatureDefinition.findUnique({ where: { key: dto.key } })
+    if (exists) throw new ConflictException(`Feature com key '${dto.key}' já existe`)
+    return this.prisma.planFeatureDefinition.create({ data: dto })
+  }
+
+  async update(id: string, dto: UpdatePlanFeatureDto) {
+    await this.findOne(id)
+    return this.prisma.planFeatureDefinition.update({ where: { id }, data: dto })
+  }
+
+  async remove(id: string) {
+    await this.findOne(id)
+    await this.prisma.planFeatureDefinition.delete({ where: { id } })
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { DashboardPage } from '@/pages/Dashboard'
 import { OrganizationsPage } from '@/pages/Organizations'
 import { OrganizationDetailPage } from '@/pages/OrganizationDetail'
 import { PlansPage } from '@/pages/Plans'
+import { PlanFeaturesPage } from '@/pages/PlanFeatures'
 import { SubscriptionsPage } from '@/pages/Subscriptions'
 import { InvoicesPage } from '@/pages/Invoices'
 
@@ -32,6 +33,7 @@ export default function App() {
             <Route path="organizations" element={<OrganizationsPage />} />
             <Route path="organizations/:id" element={<OrganizationDetailPage />} />
             <Route path="plans" element={<PlansPage />} />
+            <Route path="plan-features" element={<PlanFeaturesPage />} />
             <Route path="subscriptions" element={<SubscriptionsPage />} />
             <Route path="invoices" element={<InvoicesPage />} />
           </Route>

--- a/frontend/src/components/layout/AdminSidebar.tsx
+++ b/frontend/src/components/layout/AdminSidebar.tsx
@@ -78,12 +78,22 @@ function UserAvatar({ name, size = 28 }: { name: string; size?: number }) {
   )
 }
 
+const FeaturesIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0">
+    <path d="M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18"/>
+  </svg>
+)
+
 const navItems = [
   { to: '/dashboard',     icon: DashboardIcon, label: 'Visão geral' },
   { to: '/organizations', icon: BuildingIcon,  label: 'Organizações' },
   { to: '/plans',         icon: CardIcon,      label: 'Planos' },
   { to: '/subscriptions', icon: RefreshIcon,   label: 'Assinaturas' },
   { to: '/invoices',      icon: FileIcon,      label: 'Faturas', badge: true },
+]
+
+const planSubItems = [
+  { to: '/plan-features', icon: FeaturesIcon, label: 'Features' },
 ]
 
 export function AdminSidebar() {
@@ -186,6 +196,42 @@ export function AdminSidebar() {
             )}
           </NavLink>
         ))}
+
+        {/* Sub-itens de Planos */}
+        <div style={{ marginLeft: 14, paddingLeft: 10, borderLeft: '1px solid var(--side-border)', display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {planSubItems.map(({ to, icon: Icon, label }) => (
+            <NavLink
+              key={to}
+              to={to}
+              style={({ isActive }) => ({
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '6px 8px', borderRadius: 6,
+                fontSize: 12.5, fontWeight: isActive ? 600 : 500,
+                color: isActive ? 'var(--side-active-text)' : 'var(--side-text-2)',
+                background: isActive ? 'var(--side-active-bg)' : 'transparent',
+                textDecoration: 'none',
+                transition: 'background 80ms, color 80ms',
+              })}
+              onMouseEnter={(e) => {
+                const el = e.currentTarget
+                if (!el.getAttribute('aria-current')) {
+                  el.style.background = 'var(--side-bg-2)'
+                  el.style.color = 'var(--side-text)'
+                }
+              }}
+              onMouseLeave={(e) => {
+                const el = e.currentTarget
+                if (!el.getAttribute('aria-current')) {
+                  el.style.background = 'transparent'
+                  el.style.color = 'var(--side-text-2)'
+                }
+              }}
+            >
+              <Icon />
+              <span>{label}</span>
+            </NavLink>
+          ))}
+        </div>
       </nav>
 
       {/* System section */}

--- a/frontend/src/components/plans/PlanFormModal.tsx
+++ b/frontend/src/components/plans/PlanFormModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import { getErrorMessage } from '@/lib/utils'
 import { useToast } from '@/contexts/ToastContext'
@@ -10,23 +10,8 @@ import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import type { Plan, PlanFeatureKey } from '@/types/admin'
+import type { Plan, PlanFeatureKey, FeatureDefinition } from '@/types/admin'
 import { Plus, Pencil } from 'lucide-react'
-
-const ALL_FEATURES: { key: PlanFeatureKey; label: string }[] = [
-  { key: 'AGENDA',               label: 'Agenda' },
-  { key: 'PATIENTS',             label: 'Pacientes (ilimitados)' },
-  { key: 'FINANCIAL_BASIC',      label: 'Financeiro básico' },
-  { key: 'FINANCIAL_ADVANCED',   label: 'Relatórios financeiros avançados' },
-  { key: 'PERINEAL_ASSESSMENT',  label: 'Avaliação perineal' },
-  { key: 'TREATMENT_PACKAGES',   label: 'Pacotes de tratamento' },
-  { key: 'ANAMNESIS',            label: 'Anamnese personalizada' },
-  { key: 'EVOLUTIONS',           label: 'Prontuários e evoluções' },
-  { key: 'ROLES',                label: 'Perfis por função (Admin/Prof/Recep)' },
-  { key: 'MULTI_PROFESSIONAL',   label: 'Múltiplos profissionais' },
-  { key: 'MULTI_CLINIC',         label: 'Multi-clínica' },
-  { key: 'PRIORITY_SUPPORT',     label: 'Suporte prioritário' },
-]
 
 const schema = z.object({
   name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres'),
@@ -49,6 +34,12 @@ export function PlanFormModal({ plan }: Props) {
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const isEditing = !!plan
+
+  const { data: allFeatures = [] } = useQuery<FeatureDefinition[]>({
+    queryKey: ['plan-features'],
+    queryFn: () => api.get('/plan-features').then((r) => r.data),
+    staleTime: 60_000,
+  })
 
   const {
     register,
@@ -188,31 +179,37 @@ export function PlanFormModal({ plan }: Props) {
                 overflowY: 'auto',
               }}
             >
-              {ALL_FEATURES.map(({ key, label }, i) => (
-                <label
-                  key={key}
-                  className="flex items-center gap-2.5 cursor-pointer"
-                  style={{
-                    padding: '7px 12px',
-                    fontSize: 13,
-                    borderBottom: i < ALL_FEATURES.length - 1 ? '1px solid var(--divider)' : 'none',
-                    background: selectedFeatures.has(key) ? 'var(--ok-soft)' : 'transparent',
-                    color: selectedFeatures.has(key) ? 'var(--ok-ink)' : 'var(--text)',
-                    transition: 'background 0.1s',
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedFeatures.has(key)}
-                    onChange={() => toggleFeature(key)}
-                    style={{ accentColor: 'var(--p)', flexShrink: 0 }}
-                  />
-                  <span style={{ flex: 1 }}>{label}</span>
-                  <code style={{ fontSize: 10.5, color: 'var(--text-faint)', fontFamily: 'var(--font-mono)' }}>
-                    {key}
-                  </code>
-                </label>
-              ))}
+              {allFeatures.length === 0 ? (
+                <div style={{ padding: '16px 12px', fontSize: 13, color: 'var(--text-muted)', textAlign: 'center' }}>
+                  Nenhuma feature cadastrada. Acesse <strong>Planos → Features</strong> para cadastrar.
+                </div>
+              ) : (
+                allFeatures.map(({ key, label }, i) => (
+                  <label
+                    key={key}
+                    className="flex items-center gap-2.5 cursor-pointer"
+                    style={{
+                      padding: '7px 12px',
+                      fontSize: 13,
+                      borderBottom: i < allFeatures.length - 1 ? '1px solid var(--divider)' : 'none',
+                      background: selectedFeatures.has(key as PlanFeatureKey) ? 'var(--ok-soft)' : 'transparent',
+                      color: selectedFeatures.has(key as PlanFeatureKey) ? 'var(--ok-ink)' : 'var(--text)',
+                      transition: 'background 0.1s',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedFeatures.has(key as PlanFeatureKey)}
+                      onChange={() => toggleFeature(key as PlanFeatureKey)}
+                      style={{ accentColor: 'var(--p)', flexShrink: 0 }}
+                    />
+                    <span style={{ flex: 1 }}>{label}</span>
+                    <code style={{ fontSize: 10.5, color: 'var(--text-faint)', fontFamily: 'var(--font-mono)' }}>
+                      {key}
+                    </code>
+                  </label>
+                ))
+              )}
             </div>
           </div>
 

--- a/frontend/src/pages/PlanFeatures.tsx
+++ b/frontend/src/pages/PlanFeatures.tsx
@@ -1,0 +1,341 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { api } from '@/lib/api'
+import { getErrorMessage } from '@/lib/utils'
+import { useToast } from '@/contexts/ToastContext'
+import type { FeatureDefinition } from '@/types/admin'
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader, StatusPill } from '@/components/ui/ds'
+import { Plus, Pencil, Trash2, GripVertical } from 'lucide-react'
+
+const featureSchema = z.object({
+  key: z
+    .string()
+    .min(2)
+    .regex(/^[A-Z][A-Z0-9_]*$/, { message: 'Use UPPER_SNAKE_CASE (ex: DOCUMENTS, FINANCIAL_BASIC)' }),
+  label: z.string().min(2, 'Mínimo 2 caracteres'),
+  description: z.string().optional(),
+  sortOrder: z.coerce.number().int().min(0).optional(),
+  active: z.boolean().optional(),
+})
+
+type FeatureFormData = z.infer<typeof featureSchema>
+
+function FeatureFormDialog({
+  feature,
+  trigger,
+}: {
+  feature?: FeatureDefinition
+  trigger: React.ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+  const isEditing = !!feature
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FeatureFormData>({
+    resolver: zodResolver(featureSchema),
+    defaultValues: feature
+      ? { key: feature.key, label: feature.label, description: feature.description ?? '', sortOrder: feature.sortOrder, active: feature.active }
+      : { active: true, sortOrder: 0 },
+  })
+
+  const mutation = useMutation({
+    mutationFn: (data: FeatureFormData) =>
+      isEditing
+        ? api.patch(`/plan-features/${feature.id}`, data)
+        : api.post('/plan-features', data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan-features'] })
+      toast.success(isEditing ? 'Feature atualizada' : 'Feature criada com sucesso')
+      setOpen(false)
+      reset()
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent title={isEditing ? `Editar: ${feature.label}` : 'Nova Feature'}>
+        <form onSubmit={handleSubmit((d) => mutation.mutate(d))} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="feat-key">Chave (key) *</Label>
+            <Input
+              id="feat-key"
+              placeholder="DOCUMENTS"
+              disabled={isEditing}
+              {...register('key')}
+              error={errors.key?.message}
+              style={{ fontFamily: 'var(--font-mono)', fontSize: 13 }}
+            />
+            {!isEditing && (
+              <p style={{ fontSize: 11.5, color: 'var(--text-muted)', marginTop: 2 }}>
+                Imutável após criação. Use UPPER_SNAKE_CASE.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="feat-label">Nome de exibição *</Label>
+            <Input
+              id="feat-label"
+              placeholder="Módulo de Documentos"
+              {...register('label')}
+              error={errors.label?.message}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="feat-desc">Descrição</Label>
+            <Input
+              id="feat-desc"
+              placeholder="Permite gerar e armazenar documentos PDF para pacientes"
+              {...register('description')}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="feat-order">Ordem de exibição</Label>
+              <Input
+                id="feat-order"
+                type="number"
+                placeholder="0"
+                {...register('sortOrder')}
+                error={errors.sortOrder?.message}
+              />
+            </div>
+            <div className="flex items-end pb-1">
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input type="checkbox" {...register('active')} className="rounded border-input" />
+                Feature ativa
+              </label>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Salvando...' : isEditing ? 'Salvar Alterações' : 'Criar Feature'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteFeatureButton({ feature }: { feature: FeatureDefinition }) {
+  const [open, setOpen] = useState(false)
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const mutation = useMutation({
+    mutationFn: () => api.delete(`/plan-features/${feature.id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan-features'] })
+      toast.success('Feature removida')
+      setOpen(false)
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          title="Remover feature"
+          style={{ color: 'var(--text-muted)', cursor: 'pointer', background: 'none', border: 'none', padding: 4, borderRadius: 4, display: 'inline-flex', alignItems: 'center' }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = 'hsl(0 72% 51%)'; e.currentTarget.style.background = 'hsl(0 72% 51% / 0.1)' }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)'; e.currentTarget.style.background = 'none' }}
+        >
+          <Trash2 style={{ width: 14, height: 14 }} />
+        </button>
+      </DialogTrigger>
+      <DialogContent title="Remover Feature">
+        <p style={{ fontSize: 14, color: 'var(--text)', marginBottom: 8 }}>
+          Remover <strong>{feature.label}</strong> ({feature.key})?
+        </p>
+        <p style={{ fontSize: 12.5, color: 'var(--text-muted)', marginBottom: 20 }}>
+          Esta ação não pode ser desfeita. Planos que já contêm esta feature na lista de features não serão afetados automaticamente — você precisará removê-la manualmente deles.
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => setOpen(false)}>Cancelar</Button>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+            style={{ background: 'hsl(0 72% 51%)', color: 'white' }}
+          >
+            {mutation.isPending ? 'Removendo...' : 'Remover'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function PlanFeaturesPage() {
+  const [showInactive, setShowInactive] = useState(false)
+
+  const { data: features, isLoading } = useQuery<FeatureDefinition[]>({
+    queryKey: ['plan-features', showInactive],
+    queryFn: () =>
+      api
+        .get(`/plan-features${showInactive ? '?includeInactive=true' : ''}`)
+        .then((r) => r.data),
+  })
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <PageHeader
+        title="Features"
+        subtitle="Catálogo de funcionalidades disponíveis para configuração em planos"
+        actions={
+          <>
+            <label className="flex items-center gap-2 text-sm cursor-pointer" style={{ color: 'var(--text-muted)' }}>
+              <input
+                type="checkbox"
+                checked={showInactive}
+                onChange={(e) => setShowInactive(e.target.checked)}
+              />
+              Incluir inativas
+            </label>
+            <FeatureFormDialog
+              trigger={
+                <Button size="sm">
+                  <Plus className="h-4 w-4" />
+                  Nova Feature
+                </Button>
+              }
+            />
+          </>
+        }
+      />
+
+      <div
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--ds-border)',
+          borderRadius: 12,
+          overflow: 'hidden',
+        }}
+      >
+        {/* Table header */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '28px 160px 1fr auto 80px 64px',
+            gap: 12,
+            padding: '10px 16px',
+            borderBottom: '1px solid var(--divider)',
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: 'var(--text-muted)',
+          }}
+        >
+          <span />
+          <span>Chave</span>
+          <span>Nome / Descrição</span>
+          <span style={{ textAlign: 'center' }}>Status</span>
+          <span style={{ textAlign: 'right' }}>Ordem</span>
+          <span />
+        </div>
+
+        {isLoading ? (
+          <div style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : features && features.length > 0 ? (
+          features.map((feat, i) => (
+            <div
+              key={feat.id}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '28px 160px 1fr auto 80px 64px',
+                gap: 12,
+                padding: '11px 16px',
+                alignItems: 'center',
+                borderBottom: i < features.length - 1 ? '1px solid var(--divider)' : 'none',
+                opacity: feat.active ? 1 : 0.55,
+              }}
+            >
+              <GripVertical style={{ width: 14, height: 14, color: 'var(--text-faint)' }} />
+
+              <code style={{ fontSize: 12, fontFamily: 'var(--font-mono)', color: 'var(--text-2)', background: 'var(--surface-3)', padding: '2px 6px', borderRadius: 4 }}>
+                {feat.key}
+              </code>
+
+              <div>
+                <div style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--text)' }}>{feat.label}</div>
+                {feat.description && (
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>{feat.description}</div>
+                )}
+              </div>
+
+              <StatusPill tone={feat.active ? 'ok' : 'muted'}>
+                {feat.active ? 'Ativa' : 'Inativa'}
+              </StatusPill>
+
+              <span className="num" style={{ textAlign: 'right', fontSize: 13, color: 'var(--text-muted)' }}>
+                {feat.sortOrder}
+              </span>
+
+              <div className="flex items-center justify-end gap-1">
+                <FeatureFormDialog
+                  feature={feat}
+                  trigger={
+                    <button
+                      title="Editar feature"
+                      style={{ color: 'var(--text-muted)', cursor: 'pointer', background: 'none', border: 'none', padding: 4, borderRadius: 4, display: 'inline-flex', alignItems: 'center' }}
+                      onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--text)'; e.currentTarget.style.background = 'var(--surface-3)' }}
+                      onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)'; e.currentTarget.style.background = 'none' }}
+                    >
+                      <Pencil style={{ width: 14, height: 14 }} />
+                    </button>
+                  }
+                />
+                <DeleteFeatureButton feature={feat} />
+              </div>
+            </div>
+          ))
+        ) : (
+          <div style={{ padding: '40px 20px', textAlign: 'center', color: 'var(--text-muted)', fontSize: 14 }}>
+            Nenhuma feature cadastrada. Clique em "Nova Feature" para começar.
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          background: 'hsl(38 80% 97%)',
+          border: '1px solid hsl(38 60% 85%)',
+          borderRadius: 10,
+          padding: '12px 16px',
+          fontSize: 12.5,
+          color: 'hsl(30 40% 40%)',
+        }}
+      >
+        <strong>Como usar:</strong> Após cadastrar uma feature aqui, edite os planos desejados e marque essa feature na lista. As features ativas aparecem como opções ao configurar um plano.
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -1,24 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
-import type { Plan, PlanFeatureKey } from '@/types/admin'
+import type { Plan, FeatureDefinition } from '@/types/admin'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlanFormModal } from '@/components/plans/PlanFormModal'
 import { StatusPill, PageHeader } from '@/components/ui/ds'
-
-const FEATURE_LABELS: Record<PlanFeatureKey, string> = {
-  AGENDA:              'Agenda',
-  PATIENTS:            'Pacientes (ilimitados)',
-  FINANCIAL_BASIC:     'Financeiro básico',
-  FINANCIAL_ADVANCED:  'Relatórios financeiros avançados',
-  PERINEAL_ASSESSMENT: 'Avaliação perineal',
-  TREATMENT_PACKAGES:  'Pacotes de tratamento',
-  ANAMNESIS:           'Anamnese personalizada',
-  EVOLUTIONS:          'Prontuários e evoluções',
-  ROLES:               'Perfis por função',
-  MULTI_PROFESSIONAL:  'Múltiplos profissionais',
-  MULTI_CLINIC:        'Multi-clínica',
-  PRIORITY_SUPPORT:    'Suporte prioritário',
-}
 
 const CheckIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ width: 10, height: 10 }}>
@@ -37,7 +22,7 @@ const PLAN_COLORS: Record<string, { border: string; shadow?: string; accent: str
   Scale:     { border: 'hsl(20 25% 28%)', accent: 'hsl(20 25% 18%)' },
 }
 
-function PlanCard({ plan, isHighlight }: { plan: Plan; isHighlight: boolean }) {
+function PlanCard({ plan, isHighlight, featureLabels }: { plan: Plan; isHighlight: boolean; featureLabels: Record<string, string> }) {
   const colors = PLAN_COLORS[plan.name] ?? PLAN_COLORS.Essential
   const maxUsers = plan.maxUsers >= 999 ? 'Ilimitado' : plan.maxUsers
   const maxPatients = plan.maxPatients >= 999999 ? 'Ilimitado' : plan.maxPatients.toLocaleString('pt-BR')
@@ -126,7 +111,7 @@ function PlanCard({ plan, isHighlight }: { plan: Plan; isHighlight: boolean }) {
                 }}>
                   <CheckIcon />
                 </span>
-                {FEATURE_LABELS[key as PlanFeatureKey] ?? key}
+                {featureLabels[key] ?? key}
               </div>
             ))}
           </div>
@@ -149,6 +134,16 @@ export function PlansPage() {
     queryKey: ['plans'],
     queryFn: () => api.get('/plans').then((r) => r.data),
   })
+
+  const { data: featuredefs = [] } = useQuery<FeatureDefinition[]>({
+    queryKey: ['plan-features'],
+    queryFn: () => api.get('/plan-features').then((r) => r.data),
+    staleTime: 60_000,
+  })
+
+  const featureLabels: Record<string, string> = Object.fromEntries(
+    featuredefs.map((f) => [f.key, f.label])
+  )
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
@@ -182,7 +177,7 @@ export function PlansPage() {
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
           {plans?.map((plan) => (
-            <PlanCard key={plan.id} plan={plan} isHighlight={plan.name === PLAN_HIGHLIGHT} />
+            <PlanCard key={plan.id} plan={plan} isHighlight={plan.name === PLAN_HIGHLIGHT} featureLabels={featureLabels} />
           ))}
         </div>
       )}

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -25,23 +25,8 @@ export interface Organization {
   userCount?: number | null
 }
 
-// Feature keys habilitadas num plano — alinhado com PlanFeature em pelvi-ui
-// A lista completa e autoritativa vem de GET /plan-features (PlanFeatureDefinition no banco)
-export type PlanFeatureKey =
-  | 'AGENDA'
-  | 'PATIENTS'
-  | 'FINANCIAL_BASIC'
-  | 'FINANCIAL_ADVANCED'
-  | 'PERINEAL_ASSESSMENT'
-  | 'TREATMENT_PACKAGES'
-  | 'ANAMNESIS'
-  | 'EVOLUTIONS'
-  | 'ROLES'
-  | 'MULTI_PROFESSIONAL'
-  | 'MULTI_CLINIC'
-  | 'PRIORITY_SUPPORT'
-  | 'DOCUMENTS'
-  | (string & {}) // permite keys futuras cadastradas via admin sem rebuild
+// Feature keys habilitadas num plano — lista autoritativa vem de GET /plan-features (DB)
+export type PlanFeatureKey = string
 
 export interface FeatureDefinition {
   id: string

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -26,6 +26,7 @@ export interface Organization {
 }
 
 // Feature keys habilitadas num plano — alinhado com PlanFeature em pelvi-ui
+// A lista completa e autoritativa vem de GET /plan-features (PlanFeatureDefinition no banco)
 export type PlanFeatureKey =
   | 'AGENDA'
   | 'PATIENTS'
@@ -39,6 +40,19 @@ export type PlanFeatureKey =
   | 'MULTI_PROFESSIONAL'
   | 'MULTI_CLINIC'
   | 'PRIORITY_SUPPORT'
+  | 'DOCUMENTS'
+  | (string & {}) // permite keys futuras cadastradas via admin sem rebuild
+
+export interface FeatureDefinition {
+  id: string
+  key: string
+  label: string
+  description: string | null
+  active: boolean
+  sortOrder: number
+  createdAt: string
+  updatedAt: string
+}
 
 export interface Plan {
   id: string


### PR DESCRIPTION
- Created migration for `plan_feature_definitions` table.
- Added `PlanFeatureDefinition` model to Prisma schema.
- Implemented seeding for initial feature definitions.
- Developed RESTful API for managing plan features with CRUD operations.
- Created DTOs for creating and updating plan features.
- Built frontend components for displaying and managing plan features.
- Updated plans page to dynamically fetch and display feature labels.
- Enhanced admin sidebar to include navigation to plan features.