### PR TITLE
fix: pass plan name to pelvi-ui when updating clinic access

### DIFF
--- a/backend/src/clinic-api/clinic-api.service.ts
+++ b/backend/src/clinic-api/clinic-api.service.ts
@@ -196,11 +196,11 @@ export class ClinicApiService implements OnModuleInit {
   async updateClinicAccess(
     clinicId: string,
     status: ClinicAccessStatus,
-    limits?: { maxUsers: number; maxPatients: number },
+    limits?: { maxUsers: number; maxPatients: number; plan?: string },
   ): Promise<void> {
     this.logger.log(
       `Updating clinic ${clinicId} access → ${status}` +
-        (limits ? ` (maxUsers=${limits.maxUsers}, maxPatients=${limits.maxPatients})` : ''),
+        (limits ? ` (maxUsers=${limits.maxUsers}, maxPatients=${limits.maxPatients}, plan=${limits.plan ?? '-'})` : ''),
     )
 
     const res = await this.fetchWithTimeout(this.buildUrl`/api/internal/clinics/${clinicId}/access`, {

--- a/backend/src/organizations/application/change-plan-admin.usecase.ts
+++ b/backend/src/organizations/application/change-plan-admin.usecase.ts
@@ -41,6 +41,7 @@ export class ChangePlanAdminUseCase {
       await this.clinicApi.updateClinicAccess(org.clinicExternalId, 'ACTIVE', {
         maxUsers: newPlan.maxUsers,
         maxPatients: newPlan.maxPatients,
+        plan: newPlan.name,
       })
     }
 

--- a/backend/src/organizations/application/update-status.usecase.spec.ts
+++ b/backend/src/organizations/application/update-status.usecase.spec.ts
@@ -88,7 +88,7 @@ describe('UpdateOrgStatusUseCase', () => {
   })
 
   it('passes plan limits from active subscription to updateClinicAccess', async () => {
-    const sub = { plan: { maxUsers: 10, maxPatients: 500 } }
+    const sub = { plan: { maxUsers: 10, maxPatients: 500, name: 'Origem' } }
     prisma = makePrisma(sub)
     const orgEventsLocal = { record: jest.fn().mockResolvedValue(undefined), list: jest.fn() } as any
     sut = new UpdateOrgStatusUseCase(repo as any, clinicApi, prisma as any, orgEventsLocal)
@@ -101,6 +101,7 @@ describe('UpdateOrgStatusUseCase', () => {
     expect(clinicApi.updateClinicAccess).toHaveBeenCalledWith('clinic-1', 'ACTIVE', {
       maxUsers: 10,
       maxPatients: 500,
+      plan: 'Origem',
     })
   })
 

--- a/backend/src/organizations/application/update-status.usecase.ts
+++ b/backend/src/organizations/application/update-status.usecase.ts
@@ -32,7 +32,7 @@ export class UpdateOrgStatusUseCase {
         include: { plan: true },
       })
       const limits = sub
-        ? { maxUsers: sub.plan.maxUsers, maxPatients: sub.plan.maxPatients }
+        ? { maxUsers: sub.plan.maxUsers, maxPatients: sub.plan.maxPatients, plan: sub.plan.name }
         : undefined
 
       await this.clinicApi.updateClinicAccess(


### PR DESCRIPTION
## Summary
- `updateClinicAccess` enviava apenas `maxUsers` e `maxPatients` para pelvi-ui — campo `plan` nunca sincronizava
- Ao trocar plano de clínica, `organizations.plan` no Neon ficava desatualizado (ex: "SOLO" mesmo após mudar para "Origem")
- Adiciona `plan?: string` ao payload de `updateClinicAccess`
- `ChangePlanAdminUseCase` agora passa `newPlan.name`
- `UpdateOrgStatusUseCase` agora passa `sub.plan.name` (cobre reativação após suspensão)
- Spec `update-status.usecase.spec.ts` atualizado

## Dependência
Requer merge de **pelvi-ui PR #108** (`fix/plan-field-sync`) primeiro.

## Test Plan
- [ ] Trocar plano de clínica pelo admin → `organizations.plan` no Neon atualiza
- [ ] Suspender e reativar clínica → `plan` permanece correto