### PR TITLE
fix(security): cast userId to String in refresh-token where clauses

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -71,7 +71,7 @@ export class AuthService {
     if (stored.revokedAt) {
       // Reuse detection: presented token was already rotated. Revoke the whole family.
       await this.prisma.adminRefreshToken.updateMany({
-        where: { userId, revokedAt: null },
+        where: { userId: String(userId), revokedAt: null },
         data: { revokedAt: new Date() },
       })
       throw new UnauthorizedException('Refresh token reutilizado')
@@ -112,7 +112,7 @@ export class AuthService {
 
     // Revoke all existing refresh tokens (other sessions)
     await this.prisma.adminRefreshToken.updateMany({
-      where: { userId, revokedAt: null },
+      where: { userId: String(userId), revokedAt: null },
       data: { revokedAt: new Date() },
     })
 


### PR DESCRIPTION
## Summary
- Static analysis flagged a Prisma `adminRefreshToken.updateMany` where clause filtering by `userId` without an explicit runtime type guard, the shape of a NoSQL/object-injection vector.
- `userId` here comes from the validated JWT payload (`@CurrentUser()`), so live exploitation wasn't reachable today. Casting to `String()` closes the class of bug regardless of future refactors.
- Fixed both occurrences of the identical pattern in this file (reuse-detection revoke + changePassword revoke), not just the one the scanner pointed at, to avoid leaving a matching twin unpatched.

## Changes
- `auth.service.ts`: `userId: String(userId)` in both `adminRefreshToken.updateMany` calls.

## Test plan
- [x] `bun run build` (nest build) passes
- [x] `jest auth.service` — 12/12 passing

Fixes SOU-5